### PR TITLE
Extend (backward compatible) backend_params for health checks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,11 +90,15 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_http_health_check" "default" {
-  project      = "${var.project}"
-  count        = "${length(var.backend_params)}"
-  name         = "${var.name}-backend-${count.index}"
-  request_path = "${element(split(",", element(var.backend_params, count.index)), 0)}"
-  port         = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  project             = "${var.project}"
+  count               = "${length(var.backend_params)}"
+  name                = "${var.name}-backend-${count.index}"
+  request_path        = "${element(split(",", element(var.backend_params, count.index)), 0)}"
+  port                = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  timeout_sec         = "${length(split(",", element(var.backend_params, count.index))) > 4 ? replace(element(split(",", element(var.backend_params, count.index)), 4), "/[^0-9]/", "0") : 5}"
+  check_interval_sec  = "${length(split(",", element(var.backend_params, count.index))) > 4 ? replace(element(split(",", element(var.backend_params, count.index)), 5), "/[^0-9]/", "0") : 5}"
+  healthy_threshold   = "${length(split(",", element(var.backend_params, count.index))) > 4 ? element(split(",", element(var.backend_params, count.index)), 6) : 2}"
+  unhealthy_threshold = "${length(split(",", element(var.backend_params, count.index))) > 4 ? element(split(",", element(var.backend_params, count.index)), 7) : 2}"
 }
 
 # Create firewall rule for each backend in each network specified, uses mod behavior of element().


### PR DESCRIPTION
add parameters to configure health check's timeout, interval and thresholds