### PR TITLE
support terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,99 +15,149 @@
  */
 
 resource "google_compute_global_forwarding_rule" "http" {
-  project    = "${var.project}"
-  count      = "${var.http_forward ? 1 : 0}"
-  name       = "${var.name}"
-  target     = "${google_compute_target_http_proxy.default.self_link}"
-  ip_address = "${google_compute_global_address.default.address}"
+  project    = var.project
+  count      = var.http_forward ? 1 : 0
+  name       = var.name
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = google_compute_global_address.default.address
   port_range = "80"
-  depends_on = ["google_compute_global_address.default"]
+  depends_on = [google_compute_global_address.default]
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  project    = "${var.project}"
-  count      = "${var.ssl ? 1 : 0}"
+  project    = var.project
+  count      = var.ssl ? 1 : 0
   name       = "${var.name}-https"
-  target     = "${google_compute_target_https_proxy.default.self_link}"
-  ip_address = "${google_compute_global_address.default.address}"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = google_compute_global_address.default.address
   port_range = "443"
-  depends_on = ["google_compute_global_address.default"]
+  depends_on = [google_compute_global_address.default]
 }
 
 resource "google_compute_global_address" "default" {
-  project    = "${var.project}"
+  project    = var.project
   name       = "${var.name}-address"
-  ip_version = "${var.ip_version}"
+  ip_version = var.ip_version
 }
 
 # HTTP proxy when ssl is false
 resource "google_compute_target_http_proxy" "default" {
-  project = "${var.project}"
-  count   = "${var.http_forward ? 1 : 0}"
+  project = var.project
+  count   = var.http_forward ? 1 : 0
   name    = "${var.name}-http-proxy"
-  url_map = "${element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)}"
+  url_map = element(
+    compact(
+      concat([var.url_map], google_compute_url_map.default.*.self_link),
+    ),
+    0,
+  )
 }
 
 # HTTPS proxy  when ssl is true
 resource "google_compute_target_https_proxy" "default" {
-  project          = "${var.project}"
-  count            = "${var.ssl ? 1 : 0}"
-  name             = "${var.name}-https-proxy"
-  url_map          = "${element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)}"
-  ssl_certificates = ["${compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link))}"]
+  project = var.project
+  count   = var.ssl ? 1 : 0
+  name    = "${var.name}-https-proxy"
+  url_map = element(
+    compact(
+      concat([var.url_map], google_compute_url_map.default.*.self_link),
+    ),
+    0,
+  )
+  ssl_certificates = compact(
+    concat(
+      var.ssl_certificates,
+      google_compute_ssl_certificate.default.*.self_link,
+    ),
+  )
 }
 
 resource "google_compute_ssl_certificate" "default" {
-  project     = "${var.project}"
-  count       = "${(var.ssl && !var.use_ssl_certificates) ? 1 : 0}"
+  project     = var.project
+  count       = var.ssl && false == var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
-  private_key = "${var.private_key}"
-  certificate = "${var.certificate}"
+  private_key = var.private_key
+  certificate = var.certificate
 
-  lifecycle = {
+  lifecycle {
     create_before_destroy = true
   }
 }
 
 resource "google_compute_url_map" "default" {
-  project         = "${var.project}"
-  count           = "${var.create_url_map ? 1 : 0}"
+  project         = var.project
+  count           = var.create_url_map ? 1 : 0
   name            = "${var.name}-url-map"
-  default_service = "${google_compute_backend_service.default.0.self_link}"
+  default_service = google_compute_backend_service.default[0].self_link
 }
 
 resource "google_compute_backend_service" "default" {
-  project         = "${var.project}"
-  count           = "${length(var.backend_params)}"
-  name            = "${var.name}-backend-${count.index}"
-  port_name       = "${element(split(",", element(var.backend_params, count.index)), 1)}"
-  protocol        = "${var.backend_protocol}"
-  timeout_sec     = "${element(split(",", element(var.backend_params, count.index)), 3)}"
-  backend         = ["${var.backends["${count.index}"]}"]
-  health_checks   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
-  security_policy = "${var.security_policy}"
-  enable_cdn      = "${var.cdn}"
+  project     = var.project
+  count       = length(var.backend_params)
+  name        = "${var.name}-backend-${count.index}"
+  port_name   = element(split(",", element(var.backend_params, count.index)), 1)
+  protocol    = var.backend_protocol
+  timeout_sec = element(split(",", element(var.backend_params, count.index)), 3)
+  dynamic "backend" {
+    for_each = [var.backends[count.index]]
+    content {
+      balancing_mode               = lookup(backend.value, "balancing_mode", null)
+      capacity_scaler              = lookup(backend.value, "capacity_scaler", null)
+      description                  = lookup(backend.value, "description", null)
+      group                        = lookup(backend.value, "group", null)
+      max_connections              = lookup(backend.value, "max_connections", null)
+      max_connections_per_instance = lookup(backend.value, "max_connections_per_instance", null)
+      max_rate                     = lookup(backend.value, "max_rate", null)
+      max_rate_per_instance        = lookup(backend.value, "max_rate_per_instance", null)
+      max_utilization              = lookup(backend.value, "max_utilization", null)
+    }
+  }
+  health_checks = [element(
+    google_compute_http_health_check.default.*.self_link,
+    count.index,
+  )]
+  security_policy = var.security_policy
+  enable_cdn      = var.cdn
 }
 
 resource "google_compute_http_health_check" "default" {
-  project      = "${var.project}"
-  count        = "${length(var.backend_params)}"
+  project      = var.project
+  count        = length(var.backend_params)
   name         = "${var.name}-backend-${count.index}"
-  request_path = "${element(split(",", element(var.backend_params, count.index)), 0)}"
-  port         = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  request_path = element(split(",", element(var.backend_params, count.index)), 0)
+  port         = element(split(",", element(var.backend_params, count.index)), 2)
 }
 
 # Create firewall rule for each backend in each network specified, uses mod behavior of element().
 resource "google_compute_firewall" "default-hc" {
-  count         = "${length(var.firewall_networks) * length(var.backend_params)}"
-  project       = "${element(var.firewall_projects, count.index) == "default" ? var.project : element(var.firewall_projects, count.index)}"
+  count         = length(var.firewall_networks) * length(var.backend_params)
+  project       = element(var.firewall_projects, count.index) == "default" ? var.project : element(var.firewall_projects, count.index)
   name          = "${var.name}-hc-${count.index}"
-  network       = "${element(var.firewall_networks, count.index)}"
+  network       = element(var.firewall_networks, count.index)
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"]
-  target_tags   = ["${var.target_tags}"]
+  target_tags   = var.target_tags
 
   allow {
     protocol = "tcp"
-    ports    = ["${element(split(",", element(split("|", join("", list(join("|", var.backend_params), replace(format("%*s", length(var.backend_params), ""), " ", "|")))), count.index)), 2)}"]
+    ports = [element(
+      split(
+        ",",
+        element(
+          split(
+            "|",
+            join(
+              "",
+              [
+                join("|", var.backend_params),
+                replace(format("%*s", length(var.backend_params), ""), " ", "|"),
+              ],
+            ),
+          ),
+          count.index,
+        ),
+      ),
+      2,
+    )]
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-output backend_services {
+output "backend_services" {
   description = "The backend service resources."
-  value       = "${google_compute_backend_service.default.*.self_link}"
+  value       = google_compute_backend_service.default.*.self_link
 }
 
-output external_ip {
+output "external_ip" {
   description = "The external IP assigned to the global fowarding rule."
-  value       = "${google_compute_global_address.default.address}"
+  value       = google_compute_global_address.default.address
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -14,104 +14,105 @@
  * limitations under the License.
  */
 
-variable project {
+variable "project" {
   description = "The project to deploy to, if not set the default provider project is used."
   default     = ""
 }
 
-variable region {
+variable "region" {
   description = "Region for cloud resources"
   default     = "us-central1"
 }
 
-variable ip_version {
+variable "ip_version" {
   description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
   default     = ""
 }
 
-variable firewall_networks {
+variable "firewall_networks" {
   description = "Names of the networks to create firewall rules in"
-  type        = "list"
+  type        = list(string)
   default     = ["default"]
 }
 
-variable firewall_projects {
+variable "firewall_projects" {
   description = "Names of the projects to create firewall rules in"
-  type        = "list"
+  type        = list(string)
   default     = ["default"]
 }
 
-variable name {
+variable "name" {
   description = "Name for the forwarding rule and prefix for supporting resources"
 }
 
-variable target_tags {
+variable "target_tags" {
   description = "List of target tags for health check firewall rule."
-  type        = "list"
+  type        = list(string)
 }
 
-variable backends {
+variable "backends" {
   description = "Map backend indices to list of backend maps."
-  type        = "map"
+  type        = map
 }
 
-variable backend_params {
+variable "backend_params" {
   description = "Comma-separated encoded list of parameters in order: health check path, service port name, service port, backend timeout seconds"
-  type        = "list"
+  type        = list(string)
 }
 
-variable backend_protocol {
+variable "backend_protocol" {
   description = "The protocol with which to talk to the backend service"
   default     = "HTTP"
 }
 
-variable create_url_map {
+variable "create_url_map" {
   description = "Set to `false` if url_map variable is provided."
   default     = true
 }
 
-variable url_map {
+variable "url_map" {
   description = "The url_map resource to use. Default is to send all traffic to first backend."
   default     = ""
 }
 
-variable http_forward {
+variable "http_forward" {
   description = "Set to `false` to disable HTTP port 80 forward"
   default     = true
 }
 
-variable ssl {
+variable "ssl" {
   description = "Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs"
   default     = false
 }
 
-variable private_key {
+variable "private_key" {
   description = "Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty."
   default     = ""
 }
 
-variable certificate {
+variable "certificate" {
   description = "Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty."
   default     = ""
 }
 
-variable use_ssl_certificates {
+variable "use_ssl_certificates" {
   description = "If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate`"
   default     = false
 }
 
-variable ssl_certificates {
-  type        = "list"
+variable "ssl_certificates" {
+  type        = list(string)
   description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   default     = []
 }
 
-variable security_policy {
+variable "security_policy" {
   description = "The resource URL for the security policy to associate with the backend service"
   default     = ""
 }
 
-variable cdn {
+variable "cdn" {
   description = "Set to `true` to enable cdn on backend."
   default     = "false"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
#### Changes
+ use `terraform 0.12upgrade` command of terraform 0.12.3 to upgrade syntax of this module
+ fix type constraint of variable `backends` (the above command set it to `map(string)`, which is not correct)

#### Reference
+ [Upgrading to Terraform 0.12 - Terraform by HashiCorp](https://www.terraform.io/upgrade-guides/0-12.html)

Fixes #49