### PR TITLE
Update README with new "backends" syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,28 @@ module "gce-lb-http" {
   target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
   backends          = {
     "0" = [
-      { group = module.mig1.instance_group },
-      { group = module.mig2.instance_group }
+      {
+        group = module.mig1.instance_group
+        balancing_mode               = null
+        capacity_scaler              = null
+        description                  = null
+        max_connections              = null
+        max_connections_per_instance = null
+        max_rate                     = null
+        max_rate_per_instance        = null
+        max_utilization              = null
+      },
+      {
+        group = module.mig2.instance_group
+        balancing_mode               = null
+        capacity_scaler              = null
+        description                  = null
+        max_connections              = null
+        max_connections_per_instance = null
+        max_rate                     = null
+        max_rate_per_instance        = null
+        max_utilization              = null
+      }
     ],
   }
   backend_params    = [


### PR DESCRIPTION
One of the last changes in PR #52 (Terraform 0.12 compatibility) was to make all of these attributes required, or explicitly set to null if we do not want to change the default values.

The implementation across the example code was updated, but it looks like this entry in the README was missed