### PR TITLE
Remove unused region variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,12 +19,6 @@ variable "project" {
   type        = string
 }
 
-variable "region" {
-  description = "Region for cloud resources"
-  type        = string
-  default     = "us-central1"
-}
-
 variable "ip_version" {
   description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
   type        = string


### PR DESCRIPTION
Spotted #54 under the 2.0.0 milestone, and thought I'd take a look to see what's involved to properly handle the 'region' variable.

Turns out none of the resources that this module builds take 'region' as an argument, so it's an entirely unnecessary variable.

Looking back through the history of the codebase, 'region' came along the very first commit in this repository (ef1e5ccff515636de6560bb72fef93e8624cac43)... although it wasn't used then either! 🤷‍♂️