### PR TITLE
Create CHANGELOG.md and prepare 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2019-10-21
 
 ### Added
 
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2017-08-23
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.10...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v2.0.0...HEAD
 [1.0.10]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.9...1.0.10
 [1.0.9]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.7...1.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2017-08-23
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.10...HEAD
-[1.0.10]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.9...v1.0.10
-[1.0.9]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.8...v1.0.9
-[1.0.8]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.7...v1.0.8
-[1.0.7]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.6...v1.0.7
-[1.0.6]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.5...v1.0.6
-[1.0.5]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.4...v1.0.5
-[1.0.4]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.3...v1.0.4
-[1.0.3]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/terraform-google-modules/terraform-google-lb-http/releases/tag/v1.0.0
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.10...HEAD
+[1.0.10]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.9...1.0.10
+[1.0.9]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.8...1.0.9
+[1.0.8]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.7...1.0.8
+[1.0.7]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.6...1.0.7
+[1.0.6]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.5...1.0.6
+[1.0.5]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.4...1.0.5
+[1.0.4]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.3...1.0.4
+[1.0.3]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.2...1.0.3
+[1.0.2]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.1...1.0.2
+[1.0.1]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/terraform-google-modules/terraform-google-lb-http/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Terraform 0.12. [#51] [#56]
+
+### Removed
+
+- Support for Terraform 0.11. [#51]
+- Unused `region` variable. [#61]
+
 ## [1.0.10] - 2018-09-26
 
 ## [1.0.9] - 2018-09-06
@@ -40,3 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.2]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-lb-http/releases/tag/1.0.0
+
+[#61]: https://github.com/terraform-google-modules/terraform-google-lb-http/pull/61
+[#56]: https://github.com/terraform-google-modules/terraform-google-lb-http/pull/56
+[#51]: https://github.com/terraform-google-modules/terraform-google-lb-http/issues/51

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.10] - 2018-09-26
+
+## [1.0.9] - 2018-09-06
+
+## [1.0.8] - 2018-07-12
+
+## [1.0.7] - 2018-07-09
+
+## [1.0.6] - 2018-06-25
+
+## [1.0.5] - 2018-02-13
+
+## [1.0.4] - 2017-10-16
+
+## [1.0.3] - 2017-09-20
+
+## [1.0.2] - 2017-09-18
+
+## [1.0.1] - 2017-09-12
+
+## [1.0.0] - 2017-08-23
+
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.10...HEAD
+[1.0.10]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.9...v1.0.10
+[1.0.9]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.8...v1.0.9
+[1.0.8]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/terraform-google-modules/terraform-google-lb-http/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/terraform-google-modules/terraform-google-lb-http/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 Modular Global HTTP Load Balancer for GCE using forwarding rules.
 
+## Compatibility
+
+This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and 
+need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x is
+[1.0.10](https://registry.terraform.io/modules/GoogleCloudPlatform/lb-http/google/1.0.10).
+
 ## Usage
 
 ```HCL


### PR DESCRIPTION
This branch adds a CHANGELOG with an entry for 2.0.0 and placeholders for all of the previous releases, and adds a Terraform 0.12 compatibility note to the README. I would like to wait for #57 before releasing 2.0.0 but we've been sitting on this work for too long.