### PR TITLE
Allow 3.x google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add support for google provider version 3.x [#77]
 
 ## [3.0.0] - 2019-12-16
 

--- a/test/fixtures/mig_nat/main.tf
+++ b/test/fixtures/mig_nat/main.tf
@@ -18,6 +18,10 @@ resource "random_id" "random_net" {
   byte_length = 2
 }
 
+provider "google" {
+  version = "~> 3.5.0"
+}
+
 module "example" {
   source = "../../../examples/mig-nat-http-lb"
 

--- a/test/fixtures/multi_certs/main.tf
+++ b/test/fixtures/multi_certs/main.tf
@@ -18,6 +18,10 @@ resource "random_id" "random_net" {
   byte_length = 2
 }
 
+provider "google" {
+  version = "~> 3.5.0"
+}
+
 module "example" {
   source = "../../../examples/multiple-certs"
 

--- a/test/fixtures/multi_mig/main.tf
+++ b/test/fixtures/multi_mig/main.tf
@@ -18,6 +18,10 @@ resource "random_id" "random_net" {
   byte_length = 2
 }
 
+provider "google" {
+  version = "~> 3.5.0"
+}
+
 module "example" {
   source = "../../../examples/multi-mig-http-lb"
 

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = "~> 2.15"
-    google-beta = "~> 2.15"
+    google      = ">= 2.15, <4.0.0"
+    google-beta = ">= 2.15, <4.0.0"
   }
 }


### PR DESCRIPTION
Fixes #75 

Similar to the GKE update for 3.x providers, relax the constraint `>= 2.15, <4.0`  and inside tests use the latest 3.5 provider version (test setup for creating project/iam still uses 2.x provider).


WIP on getting tests passing, e2e tests seem flaky/failing for me locally.