### PR TITLE
Remove unnessary firewall source IPs.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -187,9 +187,7 @@ resource "google_compute_firewall" "default-hc" {
   network = var.firewall_networks[count.index]
   source_ranges = [
     "130.211.0.0/22",
-    "35.191.0.0/16",
-    "209.85.152.0/22",
-    "209.85.204.0/22"
+    "35.191.0.0/16"
   ]
   target_tags = var.target_tags
 


### PR DESCRIPTION
The two IP removed are for Network Load Balancer. From the document of
HTTPs Load Balancer, they are not needed.
https://cloud.google.com/load-balancing/docs/https/https-load-balancer-example?authuser=0#configuring_firewall_rules