### PR TITLE
Add default log_config in google_compute_backend_service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ need a Terraform 0.11.x-compatible version of this module, the last released ver
 ```HCL
 module "gce-lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google"
+  version           = "~> 3.1"
+
   name              = "group-http-lb"
+  project           = "my-project-id"
   target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
   backends = {
     default = {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        enable = true
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           # Each node pool instance group should be added to the backend.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ need a Terraform 0.11.x-compatible version of this module, the last released ver
 ```HCL
 module "gce-lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google"
-  version           = "~> 3.1"
-
   name              = "group-http-lb"
-  project           = "my-project-id"
   target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
   backends = {
     default = {

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -50,6 +50,11 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        enable = true
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           # Each node pool instance group should be added to the backend.

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,7 +119,7 @@ resource "google_compute_backend_service" "default" {
   }
 
   log_config {
-    enable      = true
+    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
     sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -86,6 +86,7 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider = google-beta
   for_each = var.backends
 
   project = var.project
@@ -115,6 +116,11 @@ resource "google_compute_backend_service" "default" {
       max_rate_per_endpoint        = lookup(backend.value, "max_rate_per_endpoint")
       max_utilization              = lookup(backend.value, "max_utilization")
     }
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 
   depends_on = [google_compute_health_check.default]

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -85,6 +85,9 @@ variable "backends" {
       port                = number
       host                = string
     })
+    log_config = object({
+      sample_rate = number
+    })
     groups = list(object({
       group                        = string
       balancing_mode               = string

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -86,6 +86,7 @@ variable "backends" {
       host                = string
     })
     log_config = object({
+      enable      = bool
       sample_rate = number
     })
     groups = list(object({

--- a/examples/https-gke/main.tf
+++ b/examples/https-gke/main.tf
@@ -67,6 +67,7 @@ module "gce-lb-https" {
       }
 
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
 

--- a/examples/https-gke/main.tf
+++ b/examples/https-gke/main.tf
@@ -66,6 +66,10 @@ module "gce-lb-https" {
         host                = null
       }
 
+      log_config = {
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           # Each node pool instance group should be added to the backend.

--- a/examples/https-gke/main.tf
+++ b/examples/https-gke/main.tf
@@ -67,7 +67,7 @@ module "gce-lb-https" {
       }
 
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
 

--- a/examples/mig-nat-http-lb/main.tf
+++ b/examples/mig-nat-http-lb/main.tf
@@ -115,6 +115,10 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           group                        = module.mig.instance_group

--- a/examples/mig-nat-http-lb/main.tf
+++ b/examples/mig-nat-http-lb/main.tf
@@ -116,8 +116,8 @@ module "gce-lb-http" {
       }
 
       log_config = {
-        enable = true
-        sample_rate = 1.0
+        enable      = false
+        sample_rate = null
       }
 
       groups = [

--- a/examples/mig-nat-http-lb/main.tf
+++ b/examples/mig-nat-http-lb/main.tf
@@ -116,6 +116,7 @@ module "gce-lb-http" {
       }
 
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
 

--- a/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
@@ -146,6 +146,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -201,6 +202,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -230,6 +232,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -259,6 +262,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [

--- a/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
@@ -145,6 +145,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig1.instance_group
@@ -197,6 +200,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig1.instance_group
@@ -223,6 +229,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig2.instance_group
@@ -249,6 +258,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig3.instance_group

--- a/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
@@ -146,7 +146,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -202,7 +202,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -232,7 +232,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -262,7 +262,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [

--- a/examples/multi-mig-http-lb/main.tf
+++ b/examples/multi-mig-http-lb/main.tf
@@ -102,6 +102,7 @@ module "gce-lb-http" {
       }
 
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
 

--- a/examples/multi-mig-http-lb/main.tf
+++ b/examples/multi-mig-http-lb/main.tf
@@ -101,6 +101,9 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        sample_rate = 1.0
+      }
 
       groups = [
         {

--- a/examples/multi-mig-http-lb/main.tf
+++ b/examples/multi-mig-http-lb/main.tf
@@ -102,7 +102,7 @@ module "gce-lb-http" {
       }
 
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
 

--- a/examples/multiple-certs/main.tf
+++ b/examples/multiple-certs/main.tf
@@ -146,6 +146,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -201,6 +202,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -230,6 +232,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [
@@ -259,6 +262,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
       groups = [

--- a/examples/multiple-certs/main.tf
+++ b/examples/multiple-certs/main.tf
@@ -145,6 +145,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig1.instance_group
@@ -197,6 +200,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig1.instance_group
@@ -223,6 +229,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig2.instance_group
@@ -249,6 +258,9 @@ module "gce-lb-https" {
       connection_draining_timeout_sec = null
       enable_cdn                      = false
       health_check                    = local.health_check
+      log_config = {
+        sample_rate = 1.0
+      }
       groups = [
         {
           group                        = module.mig3.instance_group

--- a/examples/multiple-certs/main.tf
+++ b/examples/multiple-certs/main.tf
@@ -146,7 +146,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -202,7 +202,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -232,7 +232,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [
@@ -262,7 +262,7 @@ module "gce-lb-https" {
       enable_cdn                      = false
       health_check                    = local.health_check
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
       groups = [

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -52,6 +52,10 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           group                        = module.mig.instance_group

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -53,7 +53,7 @@ module "gce-lb-http" {
       }
 
       log_config = {
-        enable = true
+        enable      = true
         sample_rate = 1.0
       }
 

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -53,6 +53,7 @@ module "gce-lb-http" {
       }
 
       log_config = {
+        enable = true
         sample_rate = 1.0
       }
 

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource "google_compute_backend_service" "default" {
   }
 
   log_config {
-    enable      = true
+    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
     sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider = google-beta
   for_each = var.backends
 
   project = var.project
@@ -115,6 +116,11 @@ resource "google_compute_backend_service" "default" {
       max_rate_per_endpoint        = lookup(backend.value, "max_rate_per_endpoint")
       max_utilization              = lookup(backend.value, "max_utilization")
     }
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 
   depends_on = [google_compute_health_check.default]

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -46,6 +46,11 @@ module "gce-lb-http" {
         host                = null
       }
 
+      log_config = {
+        enable = true
+        sample_rate = 1.0
+      }
+
       groups = [
         {
           # Each node pool instance group should be added to the backend.

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -119,7 +119,7 @@ resource "google_compute_backend_service" "default" {
   }
 
   log_config {
-    enable      = true
+    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
     sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -86,6 +86,7 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider = google-beta
   for_each = var.backends
 
   project = var.project
@@ -115,6 +116,11 @@ resource "google_compute_backend_service" "default" {
       max_rate_per_endpoint        = lookup(backend.value, "max_rate_per_endpoint")
       max_utilization              = lookup(backend.value, "max_utilization")
     }
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
   }
 
   depends_on = [google_compute_health_check.default]

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -85,6 +85,9 @@ variable "backends" {
       port                = number
       host                = string
     })
+    log_config = object({
+      sample_rate = number
+    })
     groups = list(object({
       group                        = string
       balancing_mode               = string

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -86,6 +86,7 @@ variable "backends" {
       host                = string
     })
     log_config = object({
+      enable      = bool
       sample_rate = number
     })
     groups = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,9 @@ variable "backends" {
       port                = number
       host                = string
     })
+    log_config = object({
+      sample_rate = number
+    })
     groups = list(object({
       group                        = string
       balancing_mode               = string

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,7 @@ variable "backends" {
       host                = string
     })
     log_config = object({
+      enable      = bool
       sample_rate = number
     })
     groups = list(object({


### PR DESCRIPTION
Fixes #85

This a breaking change. For new versions of the modules, `log_config` block in each `backend` is required.