### PR TITLE
Example/tutorial for using this module with autoneg

### DIFF
--- a/examples/gke-autoneg/README.md
+++ b/examples/gke-autoneg/README.md
@@ -1,0 +1,82 @@
+# HTTPS load balancer with existing GKE cluster example
+
+This example shows how Terraform can be combined with the [Autoneg controller](https://github.com/GoogleCloudPlatform/gke-autoneg-controller).
+Using this controller allows you to connect GKE services to load balancers managed outside of GKE, including multi-regional load balancers.
+
+## Usage
+1. Clone this repo and open the example directory.
+
+        git clone https://github.com/terraform-google-modules/terraform-google-lb-http
+        cd terraform-google-lb-http/examples/gke-autoneg
+
+1. Set a few config values:
+
+        # The project hosting our GKE cluster
+        export TF_VAR_project="my-project"
+        # The name of your network host project (can be same)
+        export TF_VAR_network_project="my-network-host-project"
+        # The name of your network
+        export TF_VAR_network_name="my-network
+        # Instance tags applied to your GKE nodes
+        export TF_VAR_firewall_target_tags='["gke-cluster-node"]'
+
+1. Create a cluster with Workload Identity enabled.
+    This can be done using the [Terraform GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine).
+
+1. Once you have a cluster, fetch credentials for accessing the cluster.
+
+        gcloud container clusters get-credentials $CLUSTER_NAME \
+            --zone us-central1-a \
+            --project $TF_VAR_project
+
+1. Use Terraform to create a namespace in the cluster and the HTTP load balancer.
+
+        terraform init
+        terraform apply
+
+4. Install the autoneg controller into the `autoneg-system` namespace:
+
+        kubectl apply -f manifests/autoneg.yaml
+
+5. Deploy a sample [Nginx service](./manifests/nginx.yaml):
+
+        kubectl apply -f manifests/nginx.yaml
+
+6. Access the nginx service through the load balancer. Note that it may take some time before the service is registered fully.
+
+        curl $(tf output endpoint)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| firewall\_target\_tags | Network tags to target for firewall rules, corresponding to your GKE nodes | list(string) | n/a | yes |
+| network\_name | The name of the network hosting your GKE cluster | string | n/a | yes |
+| network\_project | The project hosting your network | string | n/a | yes |
+| project\_id | The project hosting your GKE cluster | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backend-name | Backend service name to use in autoneg annotations |
+| endpoint | External IP to access load balancer |
+| lb | Full load balancer configuration |
+| project | Project ID configured for resources |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Troubleshooting
+
+If you see errors from the load balancer, you should first confirm that nginx is properly serving traffic by setting up local port-forwarding:
+
+```
+kubectl port-forward service/hello-neg 7000:80
+curl localhost:7000
+```
+
+If nginx is serving properly, you should check the autoneg controller for errors:
+```
+kubectl logs -l control-plane=controller-manager -c manager
+```

--- a/examples/gke-autoneg/iam.tf
+++ b/examples/gke-autoneg/iam.tf
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Create a namespace for autoneg
+resource "kubernetes_namespace" "autoneg" {
+  metadata {
+    labels = {
+      control-plane = "controller-manager"
+    }
+
+    name = "autoneg-system"
+  }
+}
+
+# Connect the Kubernetes service account with GCP
+module "workload_identity" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  version = "~> 9.0"
+
+  project_id          = var.project_id
+  name                = "autoneg-system"
+  k8s_sa_name         = "default"
+  namespace           = "${kubernetes_namespace.autoneg.metadata.0.name}"
+  use_existing_k8s_sa = true
+}
+
+# Create a role for autoneg
+resource "google_project_iam_custom_role" "autoneg" {
+  project     = var.project_id
+  role_id     = "autoneg"
+  title       = "autoneg controller"
+  description = "Allow GKE autoneg controller to update load balancers"
+  permissions = [
+    "compute.backendServices.get",
+    "compute.backendServices.update",
+    "compute.networkEndpointGroups.use",
+    "compute.healthChecks.useReadOnly"
+  ]
+}
+
+# Give the GCP SA the new autoneg role
+resource "google_project_iam_member" "autoneg" {
+  project = var.project_id
+  role    = "projects/${var.project}/roles/${google_project_iam_custom_role.autoneg.role_id}"
+  member  = module.workload_identity.gcp_service_account_fqn
+}

--- a/examples/gke-autoneg/lb.tf
+++ b/examples/gke-autoneg/lb.tf
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+module "lb-http" {
+  source = "../../modules/dynamic_backends"
+
+  project     = var.project_id
+  name        = "gke-http-lb"
+  target_tags = ["gke-gke-cluster-dev"]
+
+  firewall_projects = [var.network_project]
+  firewall_networks = [var.network_name]
+
+  backends = {
+    default = {
+      description = "GKE instances"
+      protocol    = "HTTP"
+      port        = 80
+      port_name   = "http"
+
+      timeout_sec                     = 10
+      connection_draining_timeout_sec = null
+      enable_cdn                      = false
+      affinity_cookie_ttl_sec         = null
+      session_affinity                = null
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+
+      health_check = {
+        request_path = "/"
+        host         = null
+        port         = 80
+        protocol     = "HTTP"
+        logging      = true
+
+        check_interval_sec  = 1
+        timeout_sec         = 1
+        healthy_threshold   = 1
+        unhealthy_threshold = null
+      }
+
+      groups = []
+    }
+  }
+}

--- a/examples/gke-autoneg/main.tf
+++ b/examples/gke-autoneg/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 3.19.0"
+}
+
+provider "google-beta" {
+  version = "~> 3.19.0"
+}

--- a/examples/gke-autoneg/manifests/autoneg.yaml
+++ b/examples/gke-autoneg/manifests/autoneg.yaml
@@ -1,0 +1,208 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: autoneg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: autoneg-leader-election-role
+  namespace: autoneg-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: autoneg-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: autoneg-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: autoneg-leader-election-rolebinding
+  namespace: autoneg-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: autoneg-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: autoneg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autoneg-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: autoneg-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: autoneg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autoneg-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: autoneg-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: autoneg-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    control-plane: controller-manager
+  name: autoneg-controller-manager-metrics-service
+  namespace: autoneg-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: autoneg-controller-manager
+  namespace: autoneg-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: gcr.io/soell-labs/gke-autoneg-controller:latest
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10

--- a/examples/gke-autoneg/manifests/nginx.yaml
+++ b/examples/gke-autoneg/manifests/nginx.yaml
@@ -1,0 +1,50 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-nginx
+spec:
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: hello-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello-nginx
+    spec:
+      containers:
+      - name: hello-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-neg
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"80":{}}}'
+    anthos.cft.dev/autoneg: '{"name":"gke-http-lb-backend-default", "max_rate_per_endpoint":1000}'
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: hello-nginx
+  ports:
+  - name: my-service-port
+    protocol: TCP
+    port: 80
+    targetPort: 80

--- a/examples/gke-autoneg/notes.txt
+++ b/examples/gke-autoneg/notes.txt
@@ -1,0 +1,91 @@
+1. Create a cluster with Workload Identity enabled.
+    This can be done using the [Terraform GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine).
+
+2. Once you have a cluster, fetch credentials for accessing the cluster.
+
+        ```
+        gcloud container clusters get-credentials $CLUSTER_NAME \
+            --zone us-central1-a \
+            --project $PROJECT_ID
+        ```
+
+3. Use Terraform to create a namespace in the cluster and load balancer...
+
+        ```
+        terraform apply
+        ```
+
+4. Install the autoneg controller into the `autoneg-system` namespace:
+
+        ```bash
+        kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/gke-autoneg-controller/master/deploy/autoneg.yaml
+        ```
+
+5. Deploy a sample [Nginx service](./manifests/nginx.yaml)
+
+### Troubleshooting
+
+#### Load Balancer Fails to Respond (502 Error)
+If the pods start successfully but your load balancer doesn't respond,
+you should check the logs of the autoneg controller:
+
+```
+kubectl logs -n autoneg-system \
+    $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n autoneg-system) manager
+```
+
+#### 403 Errors
+If the autoneg controller is showing errors, you will want to debug your IAM permissions.
+
+First, ensure workload identity is configured correctly by running a pod in the autoneg namespace:
+```
+kubectl run my-shell --rm -n autoneg-system -i --tty --image google/cloud-sdk:latest -- bash
+$ gcloud auth list
+# Should return autoneg-system@<PROJECT_ID>.iam.gserviceaccount.com
+```
+
+If Workload Identity is working correctly, retieve the IAM policies on the project:
+```
+$ gcloud iam roles describe --project $(terraform output project) autoneg
+includedPermissions:
+- compute.backendServices.get
+- compute.backendServices.update
+- compute.healthChecks.useReadOnly
+- compute.networkEndpointGroups.use
+```
+
+### NOTES
+Pre-req:
+
+1. Create IAM role + Service Account + KSA + link them
+
+1. Add k8s annotation
+
+```
+kubectl annotate sa -n autoneg-system default \
+    iam.gke.io/gcp-service-account=autoneg-system@${PROJECT_ID}.iam.gserviceaccount.com
+```
+
+kubectl annotate sa -n autoneg-system default \
+    iam.gke.io/gcp-service-account=autoneg-system@clf-gke-acm-dev.iam.gserviceaccount.com
+
+1. Deploy a simple web app
+
+kubectl apply -f manifests/deployment.yaml
+
+1. Deploy a service
+
+kubectl apply -f manifests/service.yaml
+
+## Debugging
+Get logs from manager:
+```
+kubectl logs $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n autoneg-system) manager
+```
+
+
+TODO:
+1. Allow existing SA for workload identity
+2. Use two clusters
+3. Write it all up on Medium
+4. Prevent load balancer module from attempting to remove groups

--- a/examples/gke-autoneg/outputs.tf
+++ b/examples/gke-autoneg/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "backend-name" {
+  value       = module.lb-http.backend_services["default"].name
+  description = "Backend service name to use in autoneg annotations"
+}
+
+output "lb" {
+  value       = module.lb-http
+  description = "Full load balancer configuration"
+}
+
+output "endpoint" {
+  value       = module.lb-http.external_ip
+  description = "External IP to access load balancer"
+}
+
+output "project" {
+  value       = var.project
+  description = "Project ID configured for resources"
+}

--- a/examples/gke-autoneg/variables.tf
+++ b/examples/gke-autoneg/variables.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The project hosting your GKE cluster"
+}
+
+variable "network_project" {
+  type        = string
+  description = "The project hosting your network"
+}
+
+variable "network_name" {
+  type        = string
+  description = "The name of the network hosting your GKE cluster"
+}
+
+variable "firewall_target_tags" {
+  type        = list(string)
+  description = "Network tags to target for firewall rules, corresponding to your GKE nodes"
+}


### PR DESCRIPTION
This PR provides an example of how to use the [Autoneg controller](https://github.com/GoogleCloudPlatform/gke-autoneg-controller/) to connect a Terraform-managed load balancer with GKE services.