### PR TITLE
fix: optionalize health check to support global NEG backend services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.0](https://www.github.com/terraform-google-modules/terraform-google-lb-http/compare/v4.0.0...v4.1.0) (2020-05-05)
 
-
 ### Features
 
 * Add health check logging support ([#98](https://www.github.com/terraform-google-modules/terraform-google-lb-http/issues/98)) ([f2b8f3c](https://www.github.com/terraform-google-modules/terraform-google-lb-http/commit/f2b8f3caf49a5ad06522d703d1ba1a101c561bb7))
 
 ## [4.0.0](https://www.github.com/terraform-google-modules/terraform-google-lb-http/compare/v3.2.0...v4.0.0) (2020-04-21)
+
 Please see the [upgrade guide](./docs/upgrading_to_v4.0.md) for details.
 
 ### ⚠ BREAKING CHANGES
@@ -27,13 +28,11 @@ Please see the [upgrade guide](./docs/upgrading_to_v4.0.md) for details.
 
 ## [3.2.0](https://www.github.com/terraform-google-modules/terraform-google-lb-http/compare/v3.1.0...v3.2.0) (2020-02-13)
 
-
 ### Features
 
 * Add submodule which ignores changes to backend group ([#81](https://www.github.com/terraform-google-modules/terraform-google-lb-http/issues/81)) ([d8d3e33](https://www.github.com/terraform-google-modules/terraform-google-lb-http/commit/d8d3e33dc3a128c8790476d44ae45f8465f9fa51))
 
 ## [3.1.0](https://www.github.com/terraform-google-modules/terraform-google-lb-http/compare/v3.0.0...v3.1.0) (2020-01-28)
-
 
 ### Features
 
@@ -42,6 +41,7 @@ Please see the [upgrade guide](./docs/upgrading_to_v4.0.md) for details.
 ## [3.0.0] - 2019-12-16
 
 ### Added
+
 - QUIC protocol support [#57]
 - Container Native Load Balancing support via NEGs [#57]
 - Allow existing IP address to be used [#25]
@@ -49,6 +49,7 @@ Please see the [upgrade guide](./docs/upgrading_to_v4.0.md) for details.
 - Add http/https target proxies to output to allow binding multiple IPs
 
 ### Changed
+
 - Update minimum terraform version to 0.12.6
 - Update google providers to 2.15
 - Move to using `for_each` for state management [#57]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ The following dependencies must be installed on the development system:
 Run `make build` to generate new module code.
 
 ### Submodules
+
 The main module Terraform code is stored in the [./autogen](./autogen) folder. Changes should be made there and then reflected into the submodules via `make build`.
 
 ### Generating Documentation for Inputs and Outputs
@@ -39,14 +40,17 @@ The general strategy for these tests is to verify the behaviour of the
 submodules, and example modules are all functionally correct.
 
 ### Test Environment
+
 The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
 
 To use this setup, you need a service account with these permissions (on a Folder or Organization):
+
 - Project Creator
 - Project Billing Manager
 
 The project that the service account belongs to must have the following APIs enabled (the setup won't
 create any resources on the service account's project):
+
 - Cloud Resource Manager
 - Cloud Billing
 - Service Usage
@@ -59,6 +63,7 @@ export SERVICE_ACCOUNT_JSON=$(< credentials.json)
 ```
 
 You will also need to set a few environment variables:
+
 ```
 export TF_VAR_org_id="your_org_id"
 export TF_VAR_folder_id="your_folder_id"
@@ -66,6 +71,7 @@ export TF_VAR_billing_account="your_billing_account_id"
 ```
 
 With these settings in place, you can prepare a test project using Docker:
+
 ```
 make docker_test_prepare
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Modular Global HTTP Load Balancer for GCE using forwarding rules.
 
 If you would like to allow for backend groups to be managed outside Terraform, such as via GKE services, see the [dynamic backends](./modules/dynamic_backends) submodule.
 
-### Load Balancer Types
+## Load Balancer Types
 
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
@@ -85,8 +85,8 @@ module "gce-lb-http" {
 
 Current version is 3.0. Upgrade guides:
 
-- [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-- [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
+* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -127,13 +127,13 @@ Current version is 3.0. Upgrade guides:
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-- [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
-- [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
-- [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
-- [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
-- [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
-- [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
-- [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
-- [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html):
-  Health check resources create for each of the (non global NEG) backend services.
-- [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to alllow health checks to the instance group.
+* [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
+* [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
+* [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
+* [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
+* [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
+* [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
+* [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
+* [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html):
+  Health check resources created for each of the (non global NEG) backend services.
+* [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to allow health checks to the instance group.

--- a/README.md
+++ b/README.md
@@ -132,5 +132,6 @@ Current version is 3.0. Upgrade guides:
 - [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
 - [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
 - [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
-- [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html): Health check resources create for each of the backend services.
+- [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html):
+  Health check resources create for each of the (non global NEG) backend services.
 - [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to alllow health checks to the instance group.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Modular Global HTTP Load Balancer for GCE using forwarding rules.
 If you would like to allow for backend groups to be managed outside Terraform, such as via GKE services, see the [dynamic backends](./modules/dynamic_backends) submodule.
 
 ### Load Balancer Types
+
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
 * [Internal load balancer](https://github.com/terraform-google-modules/terraform-google-lb-internal)
@@ -83,6 +84,7 @@ module "gce-lb-http" {
 ## Version
 
 Current version is 3.0. Upgrade guides:
+
 - [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
 - [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -10,6 +10,7 @@ As such, any changes to the `backends.groups` variable after creation will be ig
 {% endif %}
 
 ### Load Balancer Types
+
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
 * [Internal load balancer](https://github.com/terraform-google-modules/terraform-google-lb-internal)
@@ -88,6 +89,7 @@ module "gce-lb-http" {
 ## Version
 
 Current version is 3.0. Upgrade guides:
+
 - [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
 - [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -9,7 +9,7 @@ This submodule allows for configuring dynamic backend outside Terraform.
 As such, any changes to the `backends.groups` variable after creation will be ignored.
 {% endif %}
 
-### Load Balancer Types
+## Load Balancer Types
 
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
@@ -90,8 +90,8 @@ module "gce-lb-http" {
 
 Current version is 3.0. Upgrade guides:
 
-- [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-- [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
+* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -131,12 +131,13 @@ Current version is 3.0. Upgrade guides:
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-- [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
-- [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
-- [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
-- [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
-- [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
-- [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
-- [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
-- [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html): Health check resources create for each of the backend services.
-- [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to alllow health checks to the instance group.
+* [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
+* [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
+* [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
+* [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
+* [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
+* [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
+* [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
+* [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html):
+  Health check resources created for each of the (non global NEG) backend services.
+* [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to allow health checks to the instance group.

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  backends_with_healthchecks = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -137,7 +137,7 @@ resource "google_compute_backend_service" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = local.backends_with_healthchecks
+  for_each = local.health_checked_backends
   project  = var.project
   name     = "${var.name}-hc-${each.key}"
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -16,9 +16,9 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", false) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -18,6 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  backends_with_healthchecks = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -99,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", false) ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 
@@ -136,7 +137,7 @@ resource "google_compute_backend_service" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = var.backends
+  for_each = local.backends_with_healthchecks
   project  = var.project
   name     = "${var.name}-hc-${each.key}"
 

--- a/autogen/versions.tf.tmpl
+++ b/autogen/versions.tf.tmpl
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = ">= 3.17, <4.0.0"
-    google-beta = ">= 3.17, <4.0.0"
+    google      = ">= 3.32, <4.0.0"
+    google-beta = ">= 3.32, <4.0.0"
   }
 }

--- a/docs/upgrading-v2.0.0-v3.0.0.md
+++ b/docs/upgrading-v2.0.0-v3.0.0.md
@@ -56,7 +56,7 @@ The new version allows you to specify all of your backend configuration, includi
 ```HCL
 module "gce-lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google"
-	version           = "3.0.0"
+ version           = "3.0.0"
 
   name              = "group-http-lb"
   target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
@@ -118,6 +118,7 @@ resource 'projects/[PROJECT]/global/httpHealthChecks/multi-mig-lb-http-backend-0
 is already being used by 'projects/[PROJECT]/global/backendServices/multi-mig-lb-http-backend-0',
 resourceInUseByAnotherResource
 ```
+
 The reason for this is that when we are changing the backend service and health check around, then must be destroyed and then re-created.
 The dependencies here are as follows:
 
@@ -158,5 +159,3 @@ gcloud compute url-maps set-default-service multi-mig-lb-http-url-map \
 ```
 
 This will cut over your URL map to the new service. After that you'll only need to run `terraform apply` twice more to destroy the old backend and healthcheck resources. You'll do it twice because the backend takes a second to go away and the healthcheck can't be destroyed until the resources using it are also destroyed.
-
-

--- a/docs/upgrading_to_v4.0.md
+++ b/docs/upgrading_to_v4.0.md
@@ -4,6 +4,7 @@ The v4.0 release contains backwards-incompatible
 changes to the backend config.
 
 ## Backend Config
+
 `session_affinity`, `affinity_cookie_ttl_sec`, and `log_config` must now be specified
 for backends. To use the default value, specify `null`.
 

--- a/examples/multi-backend-multi-mig-bucket-https-lb/README.md
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/README.md
@@ -73,6 +73,7 @@ echo https://${EXTERNAL_IP}/group1/
 > You should see the GCP logo and instance details from the group in us-west1.
 
 4. Open URL to route mapped to us-central1 instance group:
+
 ```
 echo https://${EXTERNAL_IP}/group2/
 ```

--- a/examples/multiple-certs/README.md
+++ b/examples/multiple-certs/README.md
@@ -69,6 +69,7 @@ echo https://${EXTERNAL_IP}/group1/
 > You should see the GCP logo and instance details from the group in us-west1.
 
 4. Open URL to route mapped to us-central1 instance group:
+
 ```
 echo https://${EXTERNAL_IP}/group2/
 ```

--- a/main.tf
+++ b/main.tf
@@ -16,9 +16,9 @@
 
 
 locals {
-  address                    = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map                    = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  backends_with_healthchecks = [for backend in var.backends : backend if backend["health_check"] != null]
+  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  backends_with_healthchecks = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,9 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  address                    = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  url_map                    = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  backends_with_healthchecks = [for backend in var.backends : backend if backend["health_check"] != null]
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -99,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) == null ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 
@@ -131,7 +132,7 @@ resource "google_compute_backend_service" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = var.backends
+  for_each = local.backends_with_healthchecks
   project  = var.project
   name     = "${var.name}-hc-${each.key}"
 

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  backends_with_healthchecks = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -132,7 +132,7 @@ resource "google_compute_backend_service" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = local.backends_with_healthchecks
+  for_each = local.health_checked_backends
   project  = var.project
   name     = "${var.name}-hc-${each.key}"
 

--- a/main.tf
+++ b/main.tf
@@ -16,9 +16,9 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) == null ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", false) ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", false) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -5,7 +5,7 @@ Modular Global HTTP Load Balancer for GCE using forwarding rules.
 This submodule allows for configuring dynamic backend outside Terraform.
 As such, any changes to the `backends.groups` variable after creation will be ignored.
 
-### Load Balancer Types
+## Load Balancer Types
 
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
@@ -86,8 +86,8 @@ module "gce-lb-http" {
 
 Current version is 3.0. Upgrade guides:
 
-- [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-- [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
+* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -128,12 +128,13 @@ Current version is 3.0. Upgrade guides:
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-- [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
-- [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
-- [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
-- [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
-- [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
-- [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
-- [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
-- [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html): Health check resources create for each of the backend services.
-- [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to alllow health checks to the instance group.
+* [`google_compute_global_forwarding_rule.http`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTP forwarding rule.
+* [`google_compute_global_forwarding_rule.https`](https://www.terraform.io/docs/providers/google/r/compute_global_forwarding_rule.html): The global HTTPS forwarding rule created when `ssl` is `true`.
+* [`google_compute_target_http_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_http_proxy.html): The HTTP proxy resource that binds the url map. Created when input `ssl` is `false`.
+* [`google_compute_target_https_proxy.default`](https://www.terraform.io/docs/providers/google/r/compute_target_https_proxy.html): The HTTPS proxy resource that binds the url map. Created when input `ssl` is `true`.
+* [`google_compute_ssl_certificate.default`](https://www.terraform.io/docs/providers/google/r/compute_ssl_certificate.html): The certificate resource created when input `ssl` is `true`.
+* [`google_compute_url_map.default`](https://www.terraform.io/docs/providers/google/r/compute_url_map.html): The default URL map resource when input `url_map` is not provided.
+* [`google_compute_backend_service.default.*`](https://www.terraform.io/docs/providers/google/r/compute_backend_service.html): The backend services created for each of the `backend_params` elements.
+* [`google_compute_health_check.default.*`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html):
+  Health check resources created for each of the (non global NEG) backend services.
+* [`google_compute_firewall.default-hc`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html): Firewall rule created for each of the backed services to allow health checks to the instance group.

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -6,6 +6,7 @@ This submodule allows for configuring dynamic backend outside Terraform.
 As such, any changes to the `backends.groups` variable after creation will be ignored.
 
 ### Load Balancer Types
+
 * [TCP load balancer](https://github.com/terraform-google-modules/terraform-google-lb)
 * **HTTP/S load balancer**
 * [Internal load balancer](https://github.com/terraform-google-modules/terraform-google-lb-internal)
@@ -84,6 +85,7 @@ module "gce-lb-http" {
 ## Version
 
 Current version is 3.0. Upgrade guides:
+
 - [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
 - [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -16,9 +16,9 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  backends_with_healthchecks = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend if backend["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -135,7 +135,7 @@ resource "google_compute_backend_service" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  for_each = local.backends_with_healthchecks
+  for_each = local.health_checked_backends
   project  = var.project
   name     = "${var.name}-hc-${each.key}"
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -18,7 +18,7 @@
 locals {
   address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
   url_map = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend["health_check"] != null}
+  health_checked_backends = {for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null}
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", null) ? null : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -100,7 +100,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   security_policy                 = var.security_policy
-  health_checks                   = lookup(each.value, "health_check", false) ? [] : [google_compute_health_check.default[each.key].self_link]
+  health_checks                   = lookup(each.value, "health_check", null) ? [] : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
 

--- a/modules/dynamic_backends/versions.tf
+++ b/modules/dynamic_backends/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = ">= 3.17, <4.0.0"
-    google-beta = ">= 3.17, <4.0.0"
+    google      = ">= 3.32, <4.0.0"
+    google-beta = ">= 3.32, <4.0.0"
   }
 }

--- a/test/fixtures/mig_nat/main.tf
+++ b/test/fixtures/mig_nat/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "random_net" {
 }
 
 provider "google" {
-  version = "~> 3.17.0"
+  version = "~> 3.32.0"
 }
 
 module "example" {

--- a/test/fixtures/multi_certs/main.tf
+++ b/test/fixtures/multi_certs/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "random_net" {
 }
 
 provider "google" {
-  version = "~> 3.17.0"
+  version = "~> 3.32.0"
 }
 
 module "example" {

--- a/test/fixtures/multi_mig/main.tf
+++ b/test/fixtures/multi_mig/main.tf
@@ -19,7 +19,7 @@ resource "random_id" "random_net" {
 }
 
 provider "google" {
-  version = "~> 3.17.0"
+  version = "~> 3.32.0"
 }
 
 module "example" {

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = ">= 3.17, <4.0.0"
-    google-beta = ">= 3.17, <4.0.0"
+    google      = ">= 3.32, <4.0.0"
+    google-beta = ">= 3.32, <4.0.0"
   }
 }


### PR DESCRIPTION
Create a new local `backends_with_healthchecks` that represents all non global NEG backend services which are iterated over (as opposed to the full map of backends) to create the health check resources.

Furthermore if the value of `health_check` is null, an empty array is passed to the `compute_backend_service`'s `health_checks` argument.

Also includes linting of markdown files, as such please ignore whitespace changes for a better review experience.

fixes #105 