### PR TITLE
feat: Add support for dual-stack IP addresses - IPv4 + IPv6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,18 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
@@ -128,7 +129,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxyused by this module. |
 

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -104,16 +104,18 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
@@ -122,7 +124,8 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
@@ -131,7 +134,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxyused by this module. |
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -17,11 +17,13 @@
 
 locals {
   address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
   url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward     = var.http_forward || var.https_redirect
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -44,8 +46,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global fowarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -21,19 +21,25 @@ variable "project" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 

--- a/examples/https-gke/outputs.tf
+++ b/examples/https-gke/outputs.tf
@@ -17,3 +17,7 @@
 output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
+
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}

--- a/examples/https-redirect/outputs.tf
+++ b/examples/https-redirect/outputs.tf
@@ -18,6 +18,10 @@ output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}
+
 output "backend_services" {
   value = module.gce-lb-http.backend_services
 }

--- a/examples/mig-nat-http-lb/outputs.tf
+++ b/examples/mig-nat-http-lb/outputs.tf
@@ -18,6 +18,10 @@ output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}
+
 output "backend_services" {
   value = module.gce-lb-http.backend_services
 }

--- a/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
@@ -30,6 +30,14 @@ output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}
+
 output "asset-url" {
   value = "https://${module.gce-lb-https.external_ip}/assets/gcp-logo.svg"
+}
+
+output "asset-url-ipv6" {
+  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
 }

--- a/examples/multi-mig-http-lb/outputs.tf
+++ b/examples/multi-mig-http-lb/outputs.tf
@@ -17,3 +17,7 @@
 output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
+
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}

--- a/examples/multiple-certs/outputs.tf
+++ b/examples/multiple-certs/outputs.tf
@@ -30,6 +30,14 @@ output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}
+
 output "asset-url" {
   value = "https://${module.gce-lb-https.external_ip}/assets/gcp-logo.svg"
+}
+
+output "asset-url-ipv6" {
+  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
 }

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -19,6 +19,11 @@ output external_ip {
   value       = module.gce-lb-http.external_ip
 }
 
+output external_ipv6_address {
+  description = "The external IPv6 address assigned to the load balancer."
+  value       = module.gce-lb-http.external_ipv6_address
+}
+
 output service_project {
   description = "The service project the load balancer is in."
   value       = var.service_project

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,13 @@
 
 locals {
   address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
   url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward     = var.http_forward || var.https_redirect
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -44,8 +46,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -100,17 +100,18 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
@@ -129,7 +130,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxyused by this module. |
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -17,11 +17,13 @@
 
 locals {
   address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
   url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward     = var.http_forward || var.https_redirect
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -44,8 +46,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/modules/dynamic_backends/outputs.tf
+++ b/modules/dynamic_backends/outputs.tf
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global fowarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -21,19 +21,25 @@ variable "project" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global fowarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,19 +21,25 @@ variable "project" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 


### PR DESCRIPTION
We need to create multiple forwarding rules -
one for each (ip version address, port) combination - all pointing to the same respective proxies:

* ipv4 addr + http/80 - pointing to the **http** proxy
* ipv4 addr + https/443 - pointing to the **https** proxy
* ipv6 addr + http/80 - pointing to the **http** proxy
* ipv6 addr + https/443 - pointing to the **https** proxy

Fixes #112.

Signed-off-by: Kunal Gangakhedkar <kunalg@hotstar.com>