### PR TITLE
Allow security policies per backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Current version is 3.0. Upgrade guides:
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
@@ -119,8 +118,7 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ module "gce-lb-http" {
         },
       ]
 
-      iap_config = {
+      iap_config {
         enable               = false
         oauth2_client_id     = null
         oauth2_client_secret = null
@@ -109,6 +109,7 @@ Current version is 3.0. Upgrade guides:
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
@@ -118,7 +119,8 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", null)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -76,6 +76,7 @@ variable "backends" {
     timeout_sec                     = number
     connection_draining_timeout_sec = number
     enable_cdn                      = bool
+    security_policy                 = string
     session_affinity                = string
     affinity_cookie_ttl_sec         = number
     custom_request_headers          = list(string)
@@ -172,12 +173,6 @@ variable "ssl_certificates" {
   description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   type        = list(string)
   default     = []
-}
-
-variable "security_policy" {
-  description = "The resource URL for the security policy to associate with the backend service"
-  type        = string
-  default     = null
 }
 
 variable "cdn" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -175,6 +175,12 @@ variable "ssl_certificates" {
   default     = []
 }
 
+variable "security_policy" {
+  description = "The resource URL for the security policy to associate with the backend service"
+  type        = string
+  default     = null
+}
+
 variable "cdn" {
   description = "Set to `true` to enable cdn on backend."
   type        = bool

--- a/examples/https-gke/main.tf
+++ b/examples/https-gke/main.tf
@@ -55,6 +55,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/https-redirect/main.tf
+++ b/examples/https-redirect/main.tf
@@ -110,6 +110,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/mig-nat-http-lb/main.tf
+++ b/examples/mig-nat-http-lb/main.tf
@@ -107,6 +107,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/main.tf
@@ -145,6 +145,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -211,6 +212,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -251,6 +253,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -291,6 +294,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/multi-mig-http-lb/main.tf
+++ b/examples/multi-mig-http-lb/main.tf
@@ -89,6 +89,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/multiple-certs/main.tf
+++ b/examples/multiple-certs/main.tf
@@ -145,6 +145,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -211,6 +212,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -251,6 +253,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null
@@ -291,6 +294,7 @@ module "gce-lb-https" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -41,6 +41,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       connection_draining_timeout_sec = null
       enable_cdn                      = false
+      security_policy                 = null
       session_affinity                = null
       affinity_cookie_ttl_sec         = null
       custom_request_headers          = null

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", null)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -110,6 +110,7 @@ Current version is 3.0. Upgrade guides:
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
@@ -119,7 +120,8 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -110,7 +110,6 @@ Current version is 3.0. Upgrade guides:
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
@@ -120,8 +119,7 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", null)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -76,6 +76,7 @@ variable "backends" {
     timeout_sec                     = number
     connection_draining_timeout_sec = number
     enable_cdn                      = bool
+    security_policy                 = string
     session_affinity                = string
     affinity_cookie_ttl_sec         = number
     custom_request_headers          = list(string)
@@ -172,12 +173,6 @@ variable "ssl_certificates" {
   description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   type        = list(string)
   default     = []
-}
-
-variable "security_policy" {
-  description = "The resource URL for the security policy to associate with the backend service"
-  type        = string
-  default     = null
 }
 
 variable "cdn" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -175,6 +175,12 @@ variable "ssl_certificates" {
   default     = []
 }
 
+variable "security_policy" {
+  description = "The resource URL for the security policy to associate with the backend service"
+  type        = string
+  default     = null
+}
+
 variable "cdn" {
   description = "Set to `true` to enable cdn on backend."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,7 @@ variable "backends" {
     timeout_sec                     = number
     connection_draining_timeout_sec = number
     enable_cdn                      = bool
+    security_policy                 = string
     session_affinity                = string
     affinity_cookie_ttl_sec         = number
     custom_request_headers          = list(string)
@@ -172,12 +173,6 @@ variable "ssl_certificates" {
   description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   type        = list(string)
   default     = []
-}
-
-variable "security_policy" {
-  description = "The resource URL for the security policy to associate with the backend service"
-  type        = string
-  default     = null
 }
 
 variable "cdn" {

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,12 @@ variable "ssl_certificates" {
   default     = []
 }
 
+variable "security_policy" {
+  description = "The resource URL for the security policy to associate with the backend service"
+  type        = string
+  default     = null
+}
+
 variable "cdn" {
   description = "Set to `true` to enable cdn on backend."
   type        = bool


### PR DESCRIPTION
This PR allows attach armor security policy to specific backend service of the loadbalancer, allows usage of different security policies on a single lb with multiple backends. 