### PR TITLE
feat: Add support for dual-stack IP addresses - IPv4 + IPv6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |

--- a/README.md
+++ b/README.md
@@ -115,15 +115,15 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | IPv6 address (the actual IP address value) | string | `"null"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -109,33 +109,33 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IPv4 address (the actual IP address value) | string | `"null"` | no |
+| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |

--- a/README.md
+++ b/README.md
@@ -109,40 +109,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | IP address self link | `string` | `null` | no |
-| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global address | `bool` | `true` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | IPv4 address (the actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
+| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| ipv6\_address | IPv6 address (the actual IP address value) | string | `"null"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Current version is 3.0. Upgrade guides:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | address | IP address self link | `string` | `null` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
@@ -140,7 +141,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global forwarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -155,16 +155,18 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
@@ -173,7 +175,8 @@ Current version is 3.0. Upgrade guides:
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
 | ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_tags | List of target tags for health check firewall rule. | list(string) | n/a | yes |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
 | url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
@@ -182,7 +185,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxyused by this module. |
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -32,9 +32,6 @@ locals {
   health_checked_backends = {}
   {% endif %}
 
-  # boolean flag to control whether user wants to deploy IPv6 resources
-  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
-
   # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
   create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
@@ -69,7 +66,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
+  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -78,7 +75,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
+  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -16,12 +16,8 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  # Any other value is expected to be a valid pre-allocated IPv6 address.
-  # TODO: Add validations for the format if IPv6 (when != "new")?
-  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  address      = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
 
   url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward = var.http_forward || var.https_redirect
@@ -31,9 +27,6 @@ locals {
   {% else %}
   health_checked_backends = {}
   {% endif %}
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -83,7 +76,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = (local.create_ipv6_address) ? 1 : 0
+  count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -27,7 +27,7 @@ locals {
   health_checked_backends = {}
   {% endif %}
 
-  create_ipv6_resources   = ((local.ipv6_address != null) && (length(local.ipv6_address) > 0))
+  create_ipv6_resources   = (local.ipv6_address == null) ? false : (length(local.ipv6_address) > 0) ? true : false
 }
 
 ### IPv4 block ###

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -26,6 +26,8 @@ locals {
   {% else %}
   health_checked_backends = {}
   {% endif %}
+
+  create_ipv6_resources   = ((local.ipv6_address != null) && (length(local.ipv6_address) > 0))
 }
 
 ### IPv4 block ###
@@ -58,7 +60,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = local.create_http_forward ? 1 : 0
+  count      = (local.create_ipv6_resources && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -67,7 +69,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = var.ssl ? 1 : 0
+  count      = (local.create_ipv6_resources && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -16,10 +16,15 @@
 
 
 locals {
-  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
-  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  create_http_forward     = var.http_forward || var.https_redirect
+  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+
+  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
+  # Any other value is expected to be a valid pre-allocated IPv6 address.
+  # TODO: Add validations for the format if IPv6 (when != "new")?
+  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+
+  url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  create_http_forward = var.http_forward || var.https_redirect
 
   {% if not serverless %}{# Serverless NEGs don't support health checks #}
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
@@ -27,7 +32,11 @@ locals {
   health_checked_backends = {}
   {% endif %}
 
-  create_ipv6_resources   = (local.ipv6_address == null) ? false : (length(local.ipv6_address) > 0) ? true : false
+  # boolean flag to control whether user wants to deploy IPv6 resources
+  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
+
+  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
+  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -60,7 +69,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.create_ipv6_resources && local.create_http_forward) ? 1 : 0
+  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -69,7 +78,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.create_ipv6_resources && var.ssl) ? 1 : 0
+  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -77,7 +86,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = var.create_ipv6_address ? 1 : 0
+  count      = (local.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -16,9 +16,10 @@
 
 
 locals {
-  address             = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  create_http_forward = var.http_forward || var.https_redirect
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  create_http_forward     = var.http_forward || var.https_redirect
 
   {% if not serverless %}{# Serverless NEGs don't support health checks #}
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
@@ -27,6 +28,7 @@ locals {
   {% endif %}
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -49,8 +51,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global forwarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -30,9 +30,9 @@ variable "create_address" {
   default     = true
 }
 
-variable "create_ipv6_address" {
+variable "enable_ipv6" {
   type        = bool
-  description = "Create a new global IPv6 address"
+  description = "Enable IPv6 address on the CDN load-balancer"
   default     = false
 }
 
@@ -44,8 +44,8 @@ variable "address" {
 
 variable "ipv6_address" {
   type        = string
-  description = "Existing IPv6 address to use (the actual IP address value)"
-  default     = null
+  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
+  default     = "new"
 }
 
 {% if not serverless %}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -30,22 +30,28 @@ variable "create_address" {
   default     = true
 }
 
-variable "enable_ipv6" {
-  type        = bool
-  description = "Enable IPv6 address on the CDN load-balancer"
-  default     = false
-}
-
 variable "address" {
   type        = string
   description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
+variable "enable_ipv6" {
+  type        = bool
+  description = "Enable IPv6 address on the CDN load-balancer"
+  default     = false
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Allocate a new IPv6 address. Conflicts with \"ipv6_address\" - if both specified, \"create_ipv6_address\" takes precedence."
+  default     = false
+}
+
 variable "ipv6_address" {
   type        = string
-  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
-  default     = "new"
+  description = "An existing IPv6 address to use (the actual IP address value)"
+  default     = null
 }
 
 {% if not serverless %}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -33,7 +33,7 @@ variable "create_address" {
 variable "create_ipv6_address" {
   type        = bool
   description = "Create a new global IPv6 address"
-  default     = true
+  default     = false
 }
 
 variable "address" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -38,13 +38,13 @@ variable "create_ipv6_address" {
 
 variable "address" {
   type        = string
-  description = "IPv4 address (the actual IP address value)"
+  description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
 variable "ipv6_address" {
   type        = string
-  description = "IPv6 address (the actual IP address value)"
+  description = "Existing IPv6 address to use (the actual IP address value)"
   default     = null
 }
 

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -26,19 +26,25 @@ variable "name" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 

--- a/examples/https-gke/README.md
+++ b/examples/https-gke/README.md
@@ -182,7 +182,7 @@ terraform destroy
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip |  |
-| load-balancer-ipv6 |  |
+| load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-gke/README.md
+++ b/examples/https-gke/README.md
@@ -182,6 +182,7 @@ terraform destroy
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip | n/a |
+| load-balancer-ip |  |
+| load-balancer-ipv6 |  |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-gke/gke-node-port/main.tf
+++ b/examples/https-gke/gke-node-port/main.tf
@@ -118,12 +118,12 @@ resource "kubernetes_replication_controller" "nginx" {
           name  = "nginx"
 
           resources {
-            limits = {
+            limits {
               cpu    = "0.5"
               memory = "512Mi"
             }
 
-            requests = {
+            requests {
               cpu    = "250m"
               memory = "50Mi"
             }

--- a/examples/https-gke/gke-node-port/main.tf
+++ b/examples/https-gke/gke-node-port/main.tf
@@ -118,12 +118,12 @@ resource "kubernetes_replication_controller" "nginx" {
           name  = "nginx"
 
           resources {
-            limits {
+            limits = {
               cpu    = "0.5"
               memory = "512Mi"
             }
 
-            requests {
+            requests = {
               cpu    = "250m"
               memory = "50Mi"
             }

--- a/examples/https-gke/outputs.tf
+++ b/examples/https-gke/outputs.tf
@@ -17,3 +17,7 @@
 output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
+
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}

--- a/examples/https-gke/versions.tf
+++ b/examples/https-gke/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/https-redirect/README.md
+++ b/examples/https-redirect/README.md
@@ -74,5 +74,6 @@ terraform destroy
 |------|-------------|
 | backend\_services | n/a |
 | load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-redirect/outputs.tf
+++ b/examples/https-redirect/outputs.tf
@@ -18,6 +18,10 @@ output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}
+
 output "backend_services" {
   value = module.gce-lb-http.backend_services
 }

--- a/examples/https-redirect/versions.tf
+++ b/examples/https-redirect/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/mig-nat-http-lb/README.md
+++ b/examples/mig-nat-http-lb/README.md
@@ -78,5 +78,6 @@ terraform destroy
 |------|-------------|
 | backend\_services | n/a |
 | load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/mig-nat-http-lb/outputs.tf
+++ b/examples/mig-nat-http-lb/outputs.tf
@@ -18,6 +18,10 @@ output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}
+
 output "backend_services" {
   value = module.gce-lb-http.backend_services
 }

--- a/examples/mig-nat-http-lb/versions.tf
+++ b/examples/mig-nat-http-lb/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/multi-backend-multi-mig-bucket-https-lb/README.md
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/README.md
@@ -105,9 +105,11 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | asset-url | n/a |
+| asset-url-ipv6 | n/a |
 | group1\_region | n/a |
 | group2\_region | n/a |
 | group3\_region | n/a |
 | load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -40,7 +40,7 @@ data "template_file" "group3-startup-script" {
 
 module "mig1_template" {
   source     = "terraform-google-modules/vm/google//modules/instance_template"
-  version    = "1.0.0"
+  version    = "6.2.0"
   network    = google_compute_network.default.self_link
   subnetwork = google_compute_subnetwork.group1.self_link
   service_account = {
@@ -59,7 +59,7 @@ module "mig1_template" {
 
 module "mig1" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "1.0.0"
+  version           = "6.2.0"
   instance_template = module.mig1_template.self_link
   region            = var.group1_region
   hostname          = "${var.network_name}-group1"
@@ -91,7 +91,7 @@ module "mig2_template" {
 
 module "mig2" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "1.0.0"
+  version           = "6.2.0"
   instance_template = module.mig2_template.self_link
   region            = var.group2_region
   hostname          = "${var.network_name}-group2"
@@ -124,7 +124,7 @@ module "mig3_template" {
 
 module "mig3" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "1.0.0"
+  version           = "6.2.0"
   instance_template = module.mig3_template.self_link
   region            = var.group3_region
   hostname          = "${var.network_name}-group3"

--- a/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
@@ -30,6 +30,14 @@ output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}
+
 output "asset-url" {
   value = "https://${module.gce-lb-https.external_ip}/assets/gcp-logo.svg"
+}
+
+output "asset-url-ipv6" {
+  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
 }

--- a/examples/multi-backend-multi-mig-bucket-https-lb/versions.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/multi-mig-http-lb/README.md
+++ b/examples/multi-mig-http-lb/README.md
@@ -102,5 +102,6 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-mig-http-lb/outputs.tf
+++ b/examples/multi-mig-http-lb/outputs.tf
@@ -17,3 +17,7 @@
 output "load-balancer-ip" {
   value = module.gce-lb-http.external_ip
 }
+
+output "load-balancer-ipv6" {
+  value = module.gce-lb-http.external_ipv6_address
+}

--- a/examples/multi-mig-http-lb/versions.tf
+++ b/examples/multi-mig-http-lb/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/multiple-certs/README.md
+++ b/examples/multiple-certs/README.md
@@ -111,9 +111,11 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | asset-url | n/a |
+| asset-url-ipv6 | n/a |
 | group1\_region | n/a |
 | group2\_region | n/a |
 | group3\_region | n/a |
 | load-balancer-ip | n/a |
+| load-balancer-ipv6 | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-certs/outputs.tf
+++ b/examples/multiple-certs/outputs.tf
@@ -30,6 +30,14 @@ output "load-balancer-ip" {
   value = module.gce-lb-https.external_ip
 }
 
+output "load-balancer-ipv6" {
+  value = module.gce-lb-https.external_ipv6_address
+}
+
 output "asset-url" {
   value = "https://${module.gce-lb-https.external_ip}/assets/gcp-logo.svg"
+}
+
+output "asset-url-ipv6" {
+  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
 }

--- a/examples/multiple-certs/versions.tf
+++ b/examples/multiple-certs/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -65,6 +65,7 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | external\_ip | The external IP assigned to the load balancer. |
+| external\_ipv6\_address | The external IPv6 address assigned to the load balancer. |
 | service\_project | The service project the load balancer is in. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/shared-vpc/mig.tf
+++ b/examples/shared-vpc/mig.tf
@@ -55,7 +55,7 @@ module "cloud-nat" {
 
 module "mig_template" {
   source             = "terraform-google-modules/vm/google//modules/instance_template"
-  version            = "1.0.0"
+  version            = "6.2.0"
   network            = google_compute_network.default.self_link
   subnetwork         = var.subnetwork
   subnetwork_project = var.host_project
@@ -70,7 +70,7 @@ module "mig_template" {
 
 module "mig" {
   source            = "terraform-google-modules/vm/google//modules/mig"
-  version           = "1.0.0"
+  version           = "6.2.0"
   instance_template = module.mig_template.self_link
   region            = var.region
   hostname          = var.network

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -19,6 +19,11 @@ output external_ip {
   value       = module.gce-lb-http.external_ip
 }
 
+output external_ipv6_address {
+  description = "The external IPv6 address assigned to the load balancer."
+  value       = module.gce-lb-http.external_ipv6_address
+}
+
 output service_project {
   description = "The service project the load balancer is in."
   value       = var.service_project

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-output external_ip {
+output "external_ip" {
   description = "The external IP assigned to the load balancer."
   value       = module.gce-lb-http.external_ip
 }
 
-output external_ipv6_address {
+output "external_ipv6_address" {
   description = "The external IPv6 address assigned to the load balancer."
   value       = module.gce-lb-http.external_ipv6_address
 }
 
-output service_project {
+output "service_project" {
   description = "The service project the load balancer is in."
   value       = var.service_project
 }

--- a/examples/shared-vpc/versions.tf
+++ b/examples/shared-vpc/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.13.0"
+}

--- a/main.tf
+++ b/main.tf
@@ -16,20 +16,13 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  # Any other value is expected to be a valid pre-allocated IPv6 address.
-  # TODO: Add validations for the format if IPv6 (when != "new")?
-  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  address      = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
 
   url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward = var.http_forward || var.https_redirect
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -79,7 +72,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = (local.create_ipv6_address) ? 1 : 0
+  count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
   create_http_forward     = var.http_forward || var.https_redirect
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  create_ipv6_resources = ((local.ipv6_address != null) && (length(local.ipv6_address) > 0))
+  create_ipv6_resources = (local.ipv6_address == null) ? false : (length(local.ipv6_address) > 0) ? true : false
 }
 
 ### IPv4 block ###

--- a/main.tf
+++ b/main.tf
@@ -28,9 +28,6 @@ locals {
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  # boolean flag to control whether user wants to deploy IPv6 resources
-  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
-
   # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
   create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
@@ -65,7 +62,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
+  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -74,7 +71,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
+  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/main.tf
+++ b/main.tf
@@ -16,13 +16,14 @@
 
 
 locals {
-  address             = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  create_http_forward = var.http_forward || var.https_redirect
-
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  create_http_forward     = var.http_forward || var.https_redirect
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -45,8 +46,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -16,13 +16,23 @@
 
 
 locals {
-  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
-  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  create_http_forward     = var.http_forward || var.https_redirect
+  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+
+  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
+  # Any other value is expected to be a valid pre-allocated IPv6 address.
+  # TODO: Add validations for the format if IPv6 (when != "new")?
+  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+
+  url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  create_http_forward = var.http_forward || var.https_redirect
+
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  create_ipv6_resources = (local.ipv6_address == null) ? false : (length(local.ipv6_address) > 0) ? true : false
+  # boolean flag to control whether user wants to deploy IPv6 resources
+  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
+
+  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
+  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -55,7 +65,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.create_ipv6_resources && local.create_http_forward) ? 1 : 0
+  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -64,7 +74,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.create_ipv6_resources && var.ssl) ? 1 : 0
+  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -72,7 +82,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = var.create_ipv6_address ? 1 : 0
+  count      = (local.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -108,7 +108,7 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -102,33 +102,33 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -108,15 +108,15 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | IPv6 address (the actual IP address value) | string | `"null"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -102,40 +102,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | IP address self link | `string` | `null` | no |
-| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global address | `bool` | `true` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | IPv4 address (the actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
+| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| ipv6\_address | IPv6 address (the actual IP address value) | string | `"null"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -103,7 +103,7 @@ Current version is 3.0. Upgrade guides:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | IPv4 address (the actual IP address value) | string | `"null"` | no |
+| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | object | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -104,6 +104,7 @@ Current version is 3.0. Upgrade guides:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | address | IP address self link | `string` | `null` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
 | backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
 | cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
@@ -133,7 +134,8 @@ Current version is 3.0. Upgrade guides:
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global forwarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -108,8 +108,8 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
 | firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -16,20 +16,13 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  # Any other value is expected to be a valid pre-allocated IPv6 address.
-  # TODO: Add validations for the format if IPv6 (when != "new")?
-  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  address      = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
 
   url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward = var.http_forward || var.https_redirect
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -79,7 +72,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = (local.create_ipv6_address) ? 1 : 0
+  count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -28,9 +28,6 @@ locals {
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  # boolean flag to control whether user wants to deploy IPv6 resources
-  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
-
   # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
   create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
@@ -65,7 +62,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
+  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -74,7 +71,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
+  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -23,7 +23,7 @@ locals {
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  create_ipv6_resources = ((local.ipv6_address != null) && (length(local.ipv6_address) > 0))
+  create_ipv6_resources = (local.ipv6_address == null) ? false : (length(local.ipv6_address) > 0) ? true : false
 }
 
 ### IPv4 block ###

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -16,13 +16,15 @@
 
 
 locals {
-  address             = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-  url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
-  create_http_forward = var.http_forward || var.https_redirect
+  address                 = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address            = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  url_map                 = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
+  create_http_forward     = var.http_forward || var.https_redirect
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 }
 
+### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
@@ -45,8 +47,36 @@ resource "google_compute_global_address" "default" {
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
-  ip_version = var.ip_version
+  ip_version = "IPV4"
 }
+### IPv4 block ###
+
+### IPv6 block ###
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project    = var.project
+  count      = local.create_http_forward ? 1 : 0
+  name       = "${var.name}-ipv6-http"
+  target     = google_compute_target_http_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "80"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project    = var.project
+  count      = var.ssl ? 1 : 0
+  name       = "${var.name}-ipv6-https"
+  target     = google_compute_target_https_proxy.default[0].self_link
+  ip_address = local.ipv6_address
+  port_range = "443"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  count      = var.create_ipv6_address ? 1 : 0
+  project    = var.project
+  name       = "${var.name}-ipv6-address"
+  ip_version = "IPV6"
+}
+### IPv6 block ###
 
 # HTTP proxy when http forwarding is true
 resource "google_compute_target_http_proxy" "default" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -22,6 +22,8 @@ locals {
   create_http_forward     = var.http_forward || var.https_redirect
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
+
+  create_ipv6_resources = ((local.ipv6_address != null) && (length(local.ipv6_address) > 0))
 }
 
 ### IPv4 block ###
@@ -54,7 +56,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = local.create_http_forward ? 1 : 0
+  count      = (local.create_ipv6_resources && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -63,7 +65,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = var.ssl ? 1 : 0
+  count      = (local.create_ipv6_resources && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/modules/dynamic_backends/outputs.tf
+++ b/modules/dynamic_backends/outputs.tf
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global forwarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -30,9 +30,9 @@ variable "create_address" {
   default     = true
 }
 
-variable "create_ipv6_address" {
+variable "enable_ipv6" {
   type        = bool
-  description = "Create a new global IPv6 address"
+  description = "Enable IPv6 address on the CDN load-balancer"
   default     = false
 }
 
@@ -44,8 +44,8 @@ variable "address" {
 
 variable "ipv6_address" {
   type        = string
-  description = "Existing IPv6 address to use (the actual IP address value)"
-  default     = null
+  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
+  default     = "new"
 }
 
 variable "firewall_networks" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -30,22 +30,28 @@ variable "create_address" {
   default     = true
 }
 
-variable "enable_ipv6" {
-  type        = bool
-  description = "Enable IPv6 address on the CDN load-balancer"
-  default     = false
-}
-
 variable "address" {
   type        = string
   description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
+variable "enable_ipv6" {
+  type        = bool
+  description = "Enable IPv6 address on the CDN load-balancer"
+  default     = false
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Allocate a new IPv6 address. Conflicts with \"ipv6_address\" - if both specified, \"create_ipv6_address\" takes precedence."
+  default     = false
+}
+
 variable "ipv6_address" {
   type        = string
-  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
-  default     = "new"
+  description = "An existing IPv6 address to use (the actual IP address value)"
+  default     = null
 }
 
 variable "firewall_networks" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -33,7 +33,7 @@ variable "create_address" {
 variable "create_ipv6_address" {
   type        = bool
   description = "Create a new global IPv6 address"
-  default     = true
+  default     = false
 }
 
 variable "address" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -38,13 +38,13 @@ variable "create_ipv6_address" {
 
 variable "address" {
   type        = string
-  description = "IPv4 address (the actual IP address value)"
+  description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
 variable "ipv6_address" {
   type        = string
-  description = "IPv6 address (the actual IP address value)"
+  description = "Existing IPv6 address to use (the actual IP address value)"
   default     = null
 }
 

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -26,19 +26,25 @@ variable "name" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -68,34 +68,36 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | IP address self link | `string` | `null` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br><br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global address | `bool` | `true` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| ipv6\_address | One of "new" OR an existing IPv6 address to use (the actual IP address value) | string | `"new"` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IP assigned to the global forwarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
 

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -74,11 +74,12 @@ Current version is 3.0. Upgrade guides:
 | cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
 | certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
 | create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | One of "new" OR an existing IPv6 address to use (the actual IP address value) | string | `"new"` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -68,29 +68,29 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | Existing IPv4 address to use (the actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6_address" - if both specified, "create_ipv6_address" takes precedence. | bool | `"false"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | bool | `"false"` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br><br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -16,20 +16,13 @@
 
 
 locals {
-  address = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  # Any other value is expected to be a valid pre-allocated IPv6 address.
-  # TODO: Add validations for the format if IPv6 (when != "new")?
-  ipv6_address = (var.ipv6_address == "new") ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
+  address      = var.create_address ? join("", google_compute_global_address.default.*.address) : var.address
+  ipv6_address = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6.*.address) : var.ipv6_address
 
   url_map             = var.create_url_map ? join("", google_compute_url_map.default.*.self_link) : var.url_map
   create_http_forward = var.http_forward || var.https_redirect
 
   health_checked_backends = {}
-
-  # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
-  create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
 
 ### IPv4 block ###
@@ -79,7 +72,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  count      = (local.create_ipv6_address) ? 1 : 0
+  count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -28,9 +28,6 @@ locals {
 
   health_checked_backends = {}
 
-  # boolean flag to control whether user wants to deploy IPv6 resources
-  use_ipv6 = ((var.enable_ipv6) && (length(local.ipv6_address) > 0)) ? true : false
-
   # var.ipv6_address == "new" indicates that the user wants a new IPv6 address assigned automatically.
   create_ipv6_address = ((var.enable_ipv6) && (var.ipv6_address == "new")) ? true : false
 }
@@ -65,7 +62,7 @@ resource "google_compute_global_address" "default" {
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && local.create_http_forward) ? 1 : 0
+  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
@@ -74,7 +71,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
   project    = var.project
-  count      = (local.use_ipv6 && var.ssl) ? 1 : 0
+  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address

--- a/modules/serverless_negs/outputs.tf
+++ b/modules/serverless_negs/outputs.tf
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global forwarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -26,20 +26,26 @@ variable "name" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
   default     = true
+}
+
+variable "enable_ipv6" {
+  type        = bool
+  description = "Enable IPv6 address on the CDN load-balancer"
+  default     = false
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
-  default     = null
+  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
+  default     = "new"
 }
 
 

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -30,22 +30,28 @@ variable "create_address" {
   default     = true
 }
 
-variable "enable_ipv6" {
-  type        = bool
-  description = "Enable IPv6 address on the CDN load-balancer"
-  default     = false
-}
-
 variable "address" {
   type        = string
   description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
+variable "enable_ipv6" {
+  type        = bool
+  description = "Enable IPv6 address on the CDN load-balancer"
+  default     = false
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Allocate a new IPv6 address. Conflicts with \"ipv6_address\" - if both specified, \"create_ipv6_address\" takes precedence."
+  default     = false
+}
+
 variable "ipv6_address" {
   type        = string
-  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
-  default     = "new"
+  description = "An existing IPv6 address to use (the actual IP address value)"
+  default     = null
 }
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,8 +20,13 @@ output "backend_services" {
 }
 
 output "external_ip" {
-  description = "The external IP assigned to the global forwarding rule."
+  description = "The external IPv4 assigned to the global fowarding rule."
   value       = local.address
+}
+
+output "external_ipv6_address" {
+  description = "The external IPv6 assigned to the global fowarding rule."
+  value       = local.ipv6_address
 }
 
 output "http_proxy" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,9 +30,9 @@ variable "create_address" {
   default     = true
 }
 
-variable "create_ipv6_address" {
+variable "enable_ipv6" {
   type        = bool
-  description = "Create a new global IPv6 address"
+  description = "Enable IPv6 address on the CDN load-balancer"
   default     = false
 }
 
@@ -44,8 +44,8 @@ variable "address" {
 
 variable "ipv6_address" {
   type        = string
-  description = "Existing IPv6 address to use (the actual IP address value)"
-  default     = null
+  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
+  default     = "new"
 }
 
 variable "firewall_networks" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,22 +30,28 @@ variable "create_address" {
   default     = true
 }
 
-variable "enable_ipv6" {
-  type        = bool
-  description = "Enable IPv6 address on the CDN load-balancer"
-  default     = false
-}
-
 variable "address" {
   type        = string
   description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
+variable "enable_ipv6" {
+  type        = bool
+  description = "Enable IPv6 address on the CDN load-balancer"
+  default     = false
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Allocate a new IPv6 address. Conflicts with \"ipv6_address\" - if both specified, \"create_ipv6_address\" takes precedence."
+  default     = false
+}
+
 variable "ipv6_address" {
   type        = string
-  description = "One of \"new\" OR an existing IPv6 address to use (the actual IP address value)"
-  default     = "new"
+  description = "An existing IPv6 address to use (the actual IP address value)"
+  default     = null
 }
 
 variable "firewall_networks" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "create_address" {
 variable "create_ipv6_address" {
   type        = bool
   description = "Create a new global IPv6 address"
-  default     = true
+  default     = false
 }
 
 variable "address" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,13 +38,13 @@ variable "create_ipv6_address" {
 
 variable "address" {
   type        = string
-  description = "IPv4 address (the actual IP address value)"
+  description = "Existing IPv4 address to use (the actual IP address value)"
   default     = null
 }
 
 variable "ipv6_address" {
   type        = string
-  description = "IPv6 address (the actual IP address value)"
+  description = "Existing IPv6 address to use (the actual IP address value)"
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,19 +26,25 @@ variable "name" {
 
 variable "create_address" {
   type        = bool
-  description = "Create a new global address"
+  description = "Create a new global IPv4 address"
+  default     = true
+}
+
+variable "create_ipv6_address" {
+  type        = bool
+  description = "Create a new global IPv6 address"
   default     = true
 }
 
 variable "address" {
   type        = string
-  description = "IP address self link"
+  description = "IPv4 address (the actual IP address value)"
   default     = null
 }
 
-variable "ip_version" {
-  description = "IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4"
+variable "ipv6_address" {
   type        = string
+  description = "IPv6 address (the actual IP address value)"
   default     = null
 }
 


### PR DESCRIPTION
We need to create multiple forwarding rules -
one for each (ip version address, port) combination - all pointing to
the same proxies:

* ipv4 addr + http/80 - pointing to the **http** proxy
* ipv4 addr + https/443 - pointing to the **https** proxy
* ipv6 addr + http/80 - pointing to the **http** proxy
* ipv6 addr + https/443 - pointing to the **https** proxy

Fixes #112.

Signed-off-by: Kunal Gangakhedkar <kunalg@hotstar.com>