### PR TITLE
Syntax correction to example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "gce-lb-http" {
         },
       ]
 
-      iap_config {
+      iap_config = {
         enable               = false
         oauth2_client_id     = null
         oauth2_client_secret = null


### PR DESCRIPTION
The example under "Usage" was incorrectly missing an equals sign after `iap_config` which is not valid.