### PR TITLE
Per-backend security_policy fallback to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Current version is 3.0. Upgrade guides:
 | quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
 | security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
 | ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and `use_ssl_certificates` is `true`. | list(string) | `<list>` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
 | ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
 | target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
 | target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -115,8 +115,8 @@ resource "google_compute_backend_service" "default" {
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
-  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.
+  security_policy                 = lookup(each.value, "security_policy") == "" ? null : (lookup(each.value, "security_policy") == null ? var.security_policy : each.value.security_policy)
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -111,11 +111,12 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -53,7 +53,7 @@ resource "google_compute_target_http_proxy" "default" {
   count   = local.create_http_forward ? 1 : 0
   name    = "${var.name}-http-proxy"
   url_map = var.https_redirect == false ? local.url_map : join("", google_compute_url_map.https_redirect.*.self_link)
-} 
+}
 
 # HTTPS proxy when ssl is true
 resource "google_compute_target_https_proxy" "default" {
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/main.tf
+++ b/main.tf
@@ -111,11 +111,12 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
+  security_policy = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/main.tf
+++ b/main.tf
@@ -115,8 +115,8 @@ resource "google_compute_backend_service" "default" {
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
-  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
-  security_policy = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.
+  security_policy = lookup(each.value, "security_policy") == "" ? null : (lookup(each.value, "security_policy") == null ? var.security_policy : each.value.security_policy)
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? null : var.security_policy
+  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -111,11 +111,12 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
+  security_policy = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -115,8 +115,8 @@ resource "google_compute_backend_service" "default" {
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
-  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string).
-  security_policy = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
+  # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.
+  security_policy = lookup(each.value, "security_policy") == "" ? null : (lookup(each.value, "security_policy") == null ? var.security_policy : each.value.security_policy)
 
   dynamic "backend" {
     for_each = toset(each.value["groups"])

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -111,7 +111,7 @@ resource "google_compute_backend_service" "default" {
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
-  security_policy                 = lookup(each.value, "security_policy", var.security_policy)
+  security_policy                 = lookup(each.value, "security_policy", null) == null ? var.security_policy : each.value.security_policy
   health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
   session_affinity                = lookup(each.value, "session_affinity", null)
   affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)

--- a/variables.tf
+++ b/variables.tf
@@ -170,7 +170,7 @@ variable "use_ssl_certificates" {
 }
 
 variable "ssl_certificates" {
-  description = "SSL cert self_link list. Required if `ssl` is `true` and `use_ssl_certificates` is `true`."
+  description = "SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Proposed Change(s)

* Updates the per-backend `security_policy` fallback value to be the "global" value defined
in the module's variables i.e., `var.security_policy` rather than `null`.

1. Inherit `var.security_policy` when the `backend.security_policy` is `null`.
2. Explicitly set no security policy on a backend by setting `backend.security_policy` to `""` i.e., empty string.

## Relevant Link(s)

* https://github.com/terraform-google-modules/terraform-google-lb-http/issues/130

## Testing Strategy

1. `make build`
1. `make docker_test_lint`
1. Test using my forked branch in my code with only the `var.security_policy` value set,
expecting it to fallback to `var.security_policy` rather than `null`.
    * This didn't work because the module's `backend` variable is an object, which requires that `backend.security_policy` always be set.
1. Test using my forked branch with `var.security_policy` value set and `backend.security_policy` set explicitly to `null`, expecting it to fallback to the `var.security_policy` value.
    * This worked as expected.
1. Test using my forked branch with `var.security_policy` value set explicitly to `someval` and `backend[0].security_policy` set explicitly to `null`, `backend[1].security_policy` set to `not-null` value. Expecting `backend[0].security_policy` to equal `someval` and `backend[1].security_policy` to equal the not-null value.
    * This worked as expected.
1. Test using my forked branch with `var.security_policy` value set explicitly to `someval` and `backend[0].security_policy` set explicitly to `"" (empty string)`. Expecting `backend[0].security_policy` to be `null`.
    * This worked as expected.

If you recommend an automated testing approach (I see `test/fixtures`) I would be willing to in a bit of work to do that as time permits. I glanced at these fixtures/examples and I think it would be a lot easier to update an existing example. If you would point me at one to update, I could make that change.
