### PR TITLE
Add managed SSL certificates support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
-| managed\_ssl\_certificate | If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains. | bool | `"false"` | no |
-| managed\_ssl\_certificate\_domains | Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`. | list(string) | `<list>` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
+| managed\_ssl\_certificate | If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains. | bool | `"false"` | no |
+| managed\_ssl\_certificate\_domains | Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -69,7 +69,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -82,7 +82,7 @@ resource "google_compute_ssl_certificate" "default" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider    = google-beta
   project     = var.project
-  count       = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
   name = "${var.name}-cert"
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -62,14 +62,14 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, ), )
+  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
   ssl_policy       = var.ssl_policy
   quic_override    = var.quic ? "ENABLE" : null
 }
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -79,12 +79,23 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "default" {
+  provider    = google-beta
+  project     = var.project
+  count       = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+
+  name = "${var.name}-cert"
+
+  managed {
+    domains = var.managed_ssl_certificate_domains
+  }
+}
+
 resource "google_compute_url_map" "default" {
   project         = var.project
   count           = var.create_url_map ? 1 : 0
   name            = "${var.name}-url-map"
   default_service = google_compute_backend_service.default[keys(var.backends)[0]].self_link
-
 }
 
 resource "google_compute_url_map" "https_redirect" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -163,6 +163,18 @@ variable "certificate" {
   default     = null
 }
 
+variable "managed_ssl_certificate" {
+  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
+  type        = bool
+  default     = false
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  type        = list(string)
+  default     = []
+}
+
 variable "use_ssl_certificates" {
   description = "If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate`"
   type        = bool

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -163,14 +163,8 @@ variable "certificate" {
   default     = null
 }
 
-variable "managed_ssl_certificate" {
-  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
-  type        = bool
-  default     = false
-}
-
 variable "managed_ssl_certificate_domains" {
-  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  description = "Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`."
   type        = list(string)
   default     = []
 }

--- a/main.tf
+++ b/main.tf
@@ -62,14 +62,14 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, ), )
+  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
   ssl_policy       = var.ssl_policy
   quic_override    = var.quic ? "ENABLE" : null
 }
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -79,12 +79,23 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "default" {
+  provider = google-beta
+  project  = var.project
+  count    = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+
+  name = "${var.name}-cert"
+
+  managed {
+    domains = var.managed_ssl_certificate_domains
+  }
+}
+
 resource "google_compute_url_map" "default" {
   project         = var.project
   count           = var.create_url_map ? 1 : 0
   name            = "${var.name}-url-map"
   default_service = google_compute_backend_service.default[keys(var.backends)[0]].self_link
-
 }
 
 resource "google_compute_url_map" "https_redirect" {

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -82,7 +82,7 @@ resource "google_compute_ssl_certificate" "default" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
   name = "${var.name}-cert"
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -112,8 +112,7 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
-| managed\_ssl\_certificate | If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains. | bool | `"false"` | no |
-| managed\_ssl\_certificate\_domains | Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`. | list(string) | `<list>` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -112,6 +112,8 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
 | ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
+| managed\_ssl\_certificate | If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains. | bool | `"false"` | no |
+| managed\_ssl\_certificate\_domains | Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`. | list(string) | `<list>` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
 | project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -62,14 +62,14 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, ), )
+  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
   ssl_policy       = var.ssl_policy
   quic_override    = var.quic ? "ENABLE" : null
 }
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -79,12 +79,23 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "google_compute_managed_ssl_certificate" "default" {
+  provider = google-beta
+  project  = var.project
+  count    = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+
+  name = "${var.name}-cert"
+
+  managed {
+    domains = var.managed_ssl_certificate_domains
+  }
+}
+
 resource "google_compute_url_map" "default" {
   project         = var.project
   count           = var.create_url_map ? 1 : 0
   name            = "${var.name}-url-map"
   default_service = google_compute_backend_service.default[keys(var.backends)[0]].self_link
-
 }
 
 resource "google_compute_url_map" "https_redirect" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && ! var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -82,7 +82,7 @@ resource "google_compute_ssl_certificate" "default" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && var.managed_ssl_certificate && ! var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
   name = "${var.name}-cert"
 

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -163,6 +163,18 @@ variable "certificate" {
   default     = null
 }
 
+variable "managed_ssl_certificate" {
+  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
+  type        = bool
+  default     = false
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  type        = list(string)
+  default     = []
+}
+
 variable "use_ssl_certificates" {
   description = "If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate`"
   type        = bool

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -163,14 +163,8 @@ variable "certificate" {
   default     = null
 }
 
-variable "managed_ssl_certificate" {
-  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
-  type        = bool
-  default     = false
-}
-
 variable "managed_ssl_certificate_domains" {
-  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  description = "Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`."
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,18 @@ variable "certificate" {
   default     = null
 }
 
+variable "managed_ssl_certificate" {
+  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
+  type        = bool
+  default     = false
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  type        = list(string)
+  default     = []
+}
+
 variable "use_ssl_certificates" {
   description = "If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate`"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -163,14 +163,8 @@ variable "certificate" {
   default     = null
 }
 
-variable "managed_ssl_certificate" {
-  description = "If set together with  `ssl` and `managed_ssl_certificate_domains`, create a Google-managed SSL certificate for specified domains."
-  type        = bool
-  default     = false
-}
-
 variable "managed_ssl_certificate_domains" {
-  description = "Domain names to provision a managed SSL certificate. Required if `managed_ssl_certificate` is `true`."
+  description = "Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Introduced variables:

- ~~managed_ssl_certificate (bool)~~
- managed_ssl_certificate_domains (list[string])

A managed SSL cert is provisioned only if:
- `ssl` = `true` &&
- `len(var.managed_ssl_certificate_domains) > 0`
- `var.use_ssl_certificates` = `false`.

Similarly, an unmanaged certificate resource (`google_compute_ssl_certificate`)
is not created if ~~`managed_ssl_certificate` is set to `true`~~
`length(var.managed_ssl_certificate_domains)>0`.

I didn't add new test fixtures, however I tested manually with the
`examples/https-redirect` and it succesfully provisioned and served a managed
certificate.

Fixes #96.
cc: @morgante 