### PR TITLE
List required field in generated snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       enable_cdn                      = false
       custom_request_headers          = null
+      security_policy                 = null
 
       connection_draining_timeout_sec = null
       session_affinity                = null

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -74,6 +74,7 @@ module "lb-http" {
       {% endif %}
       enable_cdn                      = false
       custom_request_headers          = null
+      security_policy                 = null
 
       {% if not serverless %}
       connection_draining_timeout_sec = null

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -35,6 +35,7 @@ module "gce-lb-http" {
       timeout_sec                     = 10
       enable_cdn                      = false
       custom_request_headers          = null
+      security_policy                 = null
 
       connection_draining_timeout_sec = null
       session_affinity                = null

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -30,6 +30,7 @@ module "lb-http" {
       description                     = null
       enable_cdn                      = false
       custom_request_headers          = null
+      security_policy                 = null
 
 
       log_config = {


### PR DESCRIPTION
The example snippet in README.md files require security_policy field
to be specified. examples/** already employs this practice but the
file didn't reflect that.