### PR TITLE
add centos 7 source image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -108,31 +108,31 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | IP address self link | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global address | `bool` | `true` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13.0'

--- a/examples/cloudrun/README.md
+++ b/examples/cloudrun/README.md
@@ -95,17 +95,17 @@ redirect HTTP traffic to HTTPS.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| domain | Domain name to run the load balancer on. Used if `ssl` is `true`. | string | n/a | yes |
-| lb-name | Name for load balancer and associated resources | string | `"run-lb"` | no |
-| project\_id |  | string | n/a | yes |
-| region | Location for load balancer and Cloud Run resources | string | `"us-central1"` | no |
-| ssl | Run load balancer on HTTPS and provision managed certificate with provided `domain`. | bool | `"true"` | no |
+|------|-------------|------|---------|:--------:|
+| domain | Domain name to run the load balancer on. Used if `ssl` is `true`. | `string` | n/a | yes |
+| lb-name | Name for load balancer and associated resources | `string` | `"run-lb"` | no |
+| project\_id | n/a | `string` | n/a | yes |
+| region | Location for load balancer and Cloud Run resources | `string` | `"us-central1"` | no |
+| ssl | Run load balancer on HTTPS and provision managed certificate with provided `domain`. | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip |  |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-gke/README.md
+++ b/examples/https-gke/README.md
@@ -166,22 +166,22 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| backend | Map backend indices to list of backend maps. | string | n/a | yes |
-| name |  | string | `"tf-lb-https-gke"` | no |
-| network\_name |  | string | `"default"` | no |
-| project |  | string | n/a | yes |
-| region |  | string | `"us-central1"` | no |
-| service\_account |  | object | `<map>` | no |
-| service\_port |  | string | `"30000"` | no |
-| service\_port\_name |  | string | `"http"` | no |
-| target\_tags |  | string | `"tf-lb-https-gke"` | no |
-| zone |  | string | `"us-central1-f"` | no |
+|------|-------------|------|---------|:--------:|
+| backend | Map backend indices to list of backend maps. | `any` | n/a | yes |
+| name | n/a | `string` | `"tf-lb-https-gke"` | no |
+| network\_name | n/a | `string` | `"default"` | no |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | `"us-central1"` | no |
+| service\_account | n/a | <pre>object({<br>    email  = string,<br>    scopes = list(string)<br>  })</pre> | <pre>{<br>  "email": "",<br>  "scopes": [<br>    "cloud-platform"<br>  ]<br>}</pre> | no |
+| service\_port | n/a | `string` | `"30000"` | no |
+| service\_port\_name | n/a | `string` | `"http"` | no |
+| target\_tags | n/a | `string` | `"tf-lb-https-gke"` | no |
+| zone | n/a | `string` | `"us-central1-f"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip |  |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-redirect/README.md
+++ b/examples/https-redirect/README.md
@@ -62,17 +62,17 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| network\_name |  | string | `"tf-lb-https-redirect-nat"` | no |
-| project |  | string | n/a | yes |
-| region |  | string | `"us-east1"` | no |
-| zone |  | string | `"us-east1-b"` | no |
+|------|-------------|------|---------|:--------:|
+| network\_name | n/a | `string` | `"tf-lb-https-redirect-nat"` | no |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | `"us-east1"` | no |
+| zone | n/a | `string` | `"us-east1-b"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| backend\_services |  |
-| load-balancer-ip |  |
+| backend\_services | n/a |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/mig-nat-http-lb/README.md
+++ b/examples/mig-nat-http-lb/README.md
@@ -66,17 +66,17 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| network\_name |  | string | `"tf-lb-http-mig-nat"` | no |
-| project |  | string | n/a | yes |
-| region |  | string | `"us-west1"` | no |
-| zone |  | string | `"us-west1-b"` | no |
+|------|-------------|------|---------|:--------:|
+| network\_name | n/a | `string` | `"tf-lb-http-mig-nat"` | no |
+| project | n/a | `string` | n/a | yes |
+| region | n/a | `string` | `"us-west1"` | no |
+| zone | n/a | `string` | `"us-west1-b"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| backend\_services |  |
-| load-balancer-ip |  |
+| backend\_services | n/a |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-backend-multi-mig-bucket-https-lb/README.md
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/README.md
@@ -90,24 +90,24 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| group1\_region |  | string | `"us-west1"` | no |
-| group1\_zone |  | string | `"us-west1-a"` | no |
-| group2\_region |  | string | `"us-central1"` | no |
-| group2\_zone |  | string | `"us-central1-f"` | no |
-| group3\_region |  | string | `"us-east1"` | no |
-| group3\_zone |  | string | `"us-east1-b"` | no |
-| network\_name |  | string | `"ml-bk-ml-mig-bkt-s-lb"` | no |
-| project |  | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| group1\_region | n/a | `string` | `"us-west1"` | no |
+| group1\_zone | n/a | `string` | `"us-west1-a"` | no |
+| group2\_region | n/a | `string` | `"us-central1"` | no |
+| group2\_zone | n/a | `string` | `"us-central1-f"` | no |
+| group3\_region | n/a | `string` | `"us-east1"` | no |
+| group3\_zone | n/a | `string` | `"us-east1-b"` | no |
+| network\_name | n/a | `string` | `"ml-bk-ml-mig-bkt-s-lb"` | no |
+| project | n/a | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| asset-url |  |
-| group1\_region |  |
-| group2\_region |  |
-| group3\_region |  |
-| load-balancer-ip |  |
+| asset-url | n/a |
+| group1\_region | n/a |
+| group2\_region | n/a |
+| group3\_region | n/a |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -82,6 +82,8 @@ module "mig2_template" {
     scopes = ["cloud-platform"]
   }
   name_prefix    = "${var.network_name}-group2"
+  source_image_family  = "centos-7"
+  source_image_project = "centos-cloud"
   startup_script = data.template_file.group2-startup-script.rendered
   tags = [
     "${var.network_name}-group2",
@@ -115,6 +117,8 @@ module "mig3_template" {
     scopes = ["cloud-platform"]
   }
   name_prefix    = "${var.network_name}-group3"
+  source_image_family  = "centos-7"
+  source_image_project = "centos-cloud"
   startup_script = data.template_file.group3-startup-script.rendered
   tags = [
     "${var.network_name}-group3",

--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -74,7 +74,7 @@ module "mig1" {
 
 module "mig2_template" {
   source     = "terraform-google-modules/vm/google//modules/instance_template"
-  version    = "1.0.0"
+  version    = "6.0.0"
   network    = google_compute_network.default.self_link
   subnetwork = google_compute_subnetwork.group2.self_link
   service_account = {
@@ -82,8 +82,6 @@ module "mig2_template" {
     scopes = ["cloud-platform"]
   }
   name_prefix    = "${var.network_name}-group2"
-  source_image_family  = "centos-7"
-  source_image_project = "centos-cloud"
   startup_script = data.template_file.group2-startup-script.rendered
   tags = [
     "${var.network_name}-group2",
@@ -109,7 +107,7 @@ module "mig2" {
 
 module "mig3_template" {
   source     = "terraform-google-modules/vm/google//modules/instance_template"
-  version    = "1.0.0"
+  version    = "6.0.0"
   network    = google_compute_network.default.self_link
   subnetwork = google_compute_subnetwork.group3.self_link
   service_account = {
@@ -117,8 +115,6 @@ module "mig3_template" {
     scopes = ["cloud-platform"]
   }
   name_prefix    = "${var.network_name}-group3"
-  source_image_family  = "centos-7"
-  source_image_project = "centos-cloud"
   startup_script = data.template_file.group3-startup-script.rendered
   tags = [
     "${var.network_name}-group3",

--- a/examples/multi-mig-http-lb/README.md
+++ b/examples/multi-mig-http-lb/README.md
@@ -90,17 +90,17 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| group1\_region |  | string | `"us-west1"` | no |
-| group2\_region |  | string | `"us-east1"` | no |
-| network\_prefix |  | string | `"multi-mig-lb-http"` | no |
-| project |  | string | n/a | yes |
-| target\_size |  | number | `"2"` | no |
+|------|-------------|------|---------|:--------:|
+| group1\_region | n/a | `string` | `"us-west1"` | no |
+| group2\_region | n/a | `string` | `"us-east1"` | no |
+| network\_prefix | n/a | `string` | `"multi-mig-lb-http"` | no |
+| project | n/a | `string` | n/a | yes |
+| target\_size | n/a | `number` | `2` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| load-balancer-ip |  |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-certs/README.md
+++ b/examples/multiple-certs/README.md
@@ -96,24 +96,24 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| group1\_region |  | string | `"us-west1"` | no |
-| group1\_zone |  | string | `"us-west1-a"` | no |
-| group2\_region |  | string | `"us-central1"` | no |
-| group2\_zone |  | string | `"us-central1-f"` | no |
-| group3\_region |  | string | `"us-east1"` | no |
-| group3\_zone |  | string | `"us-east1-b"` | no |
-| network\_name |  | string | `"tf-lb-https-multi-cert"` | no |
-| project |  | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| group1\_region | n/a | `string` | `"us-west1"` | no |
+| group1\_zone | n/a | `string` | `"us-west1-a"` | no |
+| group2\_region | n/a | `string` | `"us-central1"` | no |
+| group2\_zone | n/a | `string` | `"us-central1-f"` | no |
+| group3\_region | n/a | `string` | `"us-east1"` | no |
+| group3\_zone | n/a | `string` | `"us-east1-b"` | no |
+| network\_name | n/a | `string` | `"tf-lb-https-multi-cert"` | no |
+| project | n/a | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| asset-url |  |
-| group1\_region |  |
-| group2\_region |  |
-| group3\_region |  |
-| load-balancer-ip |  |
+| asset-url | n/a |
+| group1\_region | n/a |
+| group2\_region | n/a |
+| group3\_region | n/a |
+| load-balancer-ip | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -52,12 +52,19 @@ terraform destroy
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| group\_size | Size of managed instance group to create | string | `"2"` | no |
-| host\_project | ID for the Shared VPC host project | string | n/a | yes |
-| network | ID of network to launch instances on | string | n/a | yes |
-| region |  | string | `"us-central1"` | no |
-| service\_project | ID for the Shared VPC service project where instances will be deployed | string | n/a | yes |
-| subnetwork | ID of subnetwork to launch instances on | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| group\_size | Size of managed instance group to create | `string` | `"2"` | no |
+| host\_project | ID for the Shared VPC host project | `any` | n/a | yes |
+| network | ID of network to launch instances on | `any` | n/a | yes |
+| region | n/a | `string` | `"us-central1"` | no |
+| service\_project | ID for the Shared VPC service project where instances will be deployed | `any` | n/a | yes |
+| subnetwork | ID of subnetwork to launch instances on | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| external\_ip | The external IP assigned to the load balancer. |
+| service\_project | The service project the load balancer is in. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -101,31 +101,31 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | IP address self link | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global address | `bool` | `true` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -67,27 +67,27 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IP address self link | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | string | `"null"` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | list(string) | `<list>` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | IP address self link | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br><br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global address | `bool` | `true` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 

--- a/test/fixtures/cloudrun/versions.tf
+++ b/test/fixtures/cloudrun/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.13.0"
 }

--- a/test/fixtures/https-redirect/versions.tf
+++ b/test/fixtures/https-redirect/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.13.0"
 }

--- a/test/fixtures/mig_nat/versions.tf
+++ b/test/fixtures/mig_nat/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.13.0"
 }

--- a/test/fixtures/multi_certs/versions.tf
+++ b/test/fixtures/multi_certs/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.13.0"
 }

--- a/test/fixtures/multi_mig/versions.tf
+++ b/test/fixtures/multi_mig/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.13.0"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project-ci-lb-http" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 8.1"
+  version = "~> 10.0"
 
   name                    = "ci-int-lb-http"
   random_project_id       = true


### PR DESCRIPTION
The CentOS 6 has reached its EOL and is no longer available as a GCE image.

Usually, it should not be an issue, but if for the instance_template module the image_family is set to empty string, terraform considers it as unset and falls back to the centos-6 image family.

This particular example is used for a Qwiklab and this issue is causing the lab to be broken. Specifying an image family/project will fix the lab and the example.