### PR TITLE
Random cert name

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,41 +109,45 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IPv4 address (actual IP address value) | string | `"null"` | no |
-| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxyused by this module. |
+| https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -109,44 +109,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
+| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxy used by this module. |
-| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
+| https\_proxy | The HTTPS proxyused by this module. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -97,7 +97,6 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -128,7 +128,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = random_id.certificate.hex
+  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert" 
 
   lifecycle {
     create_before_destroy = true

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -128,7 +128,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert" 
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert" 
 
   lifecycle {
     create_before_destroy = true

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -128,7 +128,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert" 
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -84,12 +84,25 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "random_id" "certificate" {
+  byte_length = 4
+  prefix      = "${var.name}-cert-"
+
+  keepers = {
+    domains = join(",", var.managed_ssl_certificate_domains)
+  }
+}
+
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
-  name = "${var.name}-cert"
+  name     = random_id.certificate.hex
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   managed {
     domains = var.managed_ssl_certificate_domains

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -229,3 +229,9 @@ variable "https_redirect" {
   type        = bool
   default     = false
 }
+
+variable "random_certificate_suffix"
+  description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
+  type        = bool
+  default     = false
+}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -230,7 +230,7 @@ variable "https_redirect" {
   default     = false
 }
 
-variable "random_certificate_suffix"
+variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool
   default     = false

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -65,7 +65,6 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | external\_ip | The external IP assigned to the load balancer. |
-| external\_ipv6\_address | The external IPv6 address assigned to the load balancer, if enabled; else "undefined" |
 | service\_project | The service project the load balancer is in. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-output external_ip {
+output "external_ip" {
   description = "The external IP assigned to the load balancer."
   value       = module.gce-lb-http.external_ip
 }
 
-output service_project {
+output "service_project" {
   description = "The service project the load balancer is in."
   value       = var.service_project
 }

--- a/main.tf
+++ b/main.tf
@@ -93,8 +93,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-
-  name = random_id.certificate.hex
+  name     = random_id.certificate.hex
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -80,12 +80,25 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "random_id" "certificate" {
+  byte_length = 4
+  prefix      = "${var.name}-cert-"
+
+  keepers = {
+    domains = join(",", var.managed_ssl_certificate_domains)
+  }
+}
+
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
-  name = "${var.name}-cert"
+  name     = random_id.certificate.hex
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   managed {
     domains = var.managed_ssl_certificate_domains

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
-  name     = random_id.certificate.hex
+  name = random_id.certificate.hex
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = random_id.certificate.hex
+  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -102,41 +102,45 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IPv4 address (actual IP address value) | string | `"null"` | no |
-| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxyused by this module. |
+| https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -102,44 +102,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br>    protocol  = string<br>    port      = number<br>    port_name = string<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br>    timeout_sec                     = number<br>    connection_draining_timeout_sec = number<br>    session_affinity                = string<br>    affinity_cookie_ttl_sec         = number<br><br>    health_check = object({<br>      check_interval_sec  = number<br>      timeout_sec         = number<br>      healthy_threshold   = number<br>      unhealthy_threshold = number<br>      request_path        = string<br>      port                = number<br>      host                = string<br>      logging             = bool<br>    })<br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>      balancing_mode               = string<br>      capacity_scaler              = number<br>      description                  = string<br>      max_connections              = number<br>      max_connections_per_instance = number<br>      max_connections_per_endpoint = number<br>      max_rate                     = number<br>      max_rate_per_instance        = number<br>      max_rate_per_endpoint        = number<br>      max_utilization              = number<br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target\_tags or target\_service\_accounts should be specified. | `list(string)` | `[]` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
+| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxy used by this module. |
-| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
+| https\_proxy | The HTTPS proxyused by this module. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -93,8 +93,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-
-  name = random_id.certificate.hex
+  name     = random_id.certificate.hex
 
   lifecycle {
     create_before_destroy = true

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -80,12 +80,25 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "random_id" "certificate" {
+  byte_length = 4
+  prefix      = "${var.name}-cert-"
+
+  keepers = {
+    domains = join(",", var.managed_ssl_certificate_domains)
+  }
+}
+
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
-  name = "${var.name}-cert"
+  name = random_id.certificate.hex
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   managed {
     domains = var.managed_ssl_certificate_domains

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = random_id.certificate.hex
+  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -217,7 +217,7 @@ variable "https_redirect" {
   default     = false
 }
 
-variable "random_certificate_suffix"
+variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool
   default     = false

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -216,3 +216,9 @@ variable "https_redirect" {
   type        = bool
   default     = false
 }
+
+variable "random_certificate_suffix"
+  description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
+  type        = bool
+  default     = false
+}

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -68,40 +68,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
-| backends | Map backend indices to list of backend maps. | <pre>map(object({<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br><br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
-| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
-| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
-| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
-| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
-| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
-| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
-| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+|------|-------------|:----:|:-----:|:-----:|
+| address | IPv4 address (actual IP address value) | string | `"null"` | no |
+| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
+| backends | Map backend indices to list of backend maps. | object | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
+| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
+| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
+| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
+| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
+| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
+| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
+| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
+| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
+| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
+| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxy used by this module. |
-| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
+| https\_proxy | The HTTPS proxyused by this module. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -68,41 +68,41 @@ Current version is 3.0. Upgrade guides:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| address | IPv4 address (actual IP address value) | string | `"null"` | no |
-| ipv6\_address | IPv6 address (actual IP address value) | string | `"null"` | no |
-| backends | Map backend indices to list of backend maps. | object | n/a | yes |
-| cdn | Set to `true` to enable cdn on backend. | bool | `"false"` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| create\_address | Create a new global IPv4 address | bool | `"true"` | no |
-| create\_ipv6\_address | Create a new global IPv6 address | bool | `"true"` | no |
-| create\_url\_map | Set to `false` if url_map variable is provided. | bool | `"true"` | no |
-| firewall\_networks | Names of the networks to create firewall rules in | list(string) | `<list>` | no |
-| firewall\_projects | Names of the projects to create firewall rules in | list(string) | `<list>` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | bool | `"true"` | no |
-| https\_redirect | Set to `true` to enable https redirect on the lb. | bool | `"false"` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | string | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | string | `"null"` | no |
-| project | The project to deploy to, if not set the default provider project is used. | string | n/a | yes |
-| quic | Set to `true` to enable QUIC support | bool | `"false"` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | string | `"null"` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self_link certs | bool | `"false"` | no |
-| ssl\_certificates | SSL cert self_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | list(string) | `<list>` | no |
-| ssl\_policy | Selfink to SSL Policy | string | `"null"` | no |
-| target\_service\_accounts | List of target service accounts for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| target\_tags | List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified. | list(string) | `<list>` | no |
-| url\_map | The url_map resource to use. Default is to send all traffic to first backend. | string | `"null"` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| address | Existing IPv4 address to use (the actual IP address value) | `string` | `null` | no |
+| backends | Map backend indices to list of backend maps. | <pre>map(object({<br><br>    description            = string<br>    enable_cdn             = bool<br>    security_policy        = string<br>    custom_request_headers = list(string)<br><br><br><br>    log_config = object({<br>      enable      = bool<br>      sample_rate = number<br>    })<br><br>    groups = list(object({<br>      group = string<br><br>    }))<br>    iap_config = object({<br>      enable               = bool<br>      oauth2_client_id     = string<br>      oauth2_client_secret = string<br>    })<br>  }))</pre> | n/a | yes |
+| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| create\_address | Create a new global IPv4 address | `bool` | `true` | no |
+| create\_ipv6\_address | Allocate a new IPv6 address. Conflicts with "ipv6\_address" - if both specified, "create\_ipv6\_address" takes precedence. | `bool` | `false` | no |
+| create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
+| enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
+| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |
+| project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
+| quic | Set to `true` to enable QUIC support | `bool` | `false` | no |
+| random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
+| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
+| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | backend\_services | The backend service resources. |
-| external\_ip | The external IPv4 address assigned to the global fowarding rule. |
-| external\_ipv6\_address | The external IPv6 address assigned to the global fowarding rule. |
+| external\_ip | The external IPv4 assigned to the global fowarding rule. |
+| external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
-| https\_proxy | The HTTPS proxyused by this module. |
+| https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -80,12 +80,25 @@ resource "google_compute_ssl_certificate" "default" {
   }
 }
 
+resource "random_id" "certificate" {
+  byte_length = 4
+  prefix      = "${var.name}-cert-"
+
+  keepers = {
+    domains = join(",", var.managed_ssl_certificate_domains)
+  }
+}
+
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
 
-  name = "${var.name}-cert"
+  name     = random_id.certificate.hex
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   managed {
     domains = var.managed_ssl_certificate_domains

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = random_id.certificate.hex
+  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert" 
 
   lifecycle {
     create_before_destroy = true

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert" 
 
   lifecycle {
     create_before_destroy = true

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -93,7 +93,6 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert" 
+  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -101,7 +101,7 @@ resource "google_compute_target_https_proxy" "default" {
 
 resource "google_compute_ssl_certificate" "default" {
   project     = var.project
-  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && !var.use_ssl_certificates ? 1 : 0
+  count       = var.ssl && length(var.managed_ssl_certificate_domains) == 0 && ! var.use_ssl_certificates ? 1 : 0
   name_prefix = "${var.name}-certificate-"
   private_key = var.private_key
   certificate = var.certificate
@@ -123,7 +123,7 @@ resource "random_id" "certificate" {
 resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
-  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && !var.use_ssl_certificates ? 1 : 0
+  count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
   name     = random_id.certificate.hex
 
   lifecycle {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert" 
+  name     = var.random_certificate_suffix ? random_id.certificate.hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -166,3 +166,9 @@ variable "https_redirect" {
   type        = bool
   default     = false
 }
+
+variable "random_certificate_suffix"
+  description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
+  type        = bool
+  default     = false
+}

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -167,7 +167,7 @@ variable "https_redirect" {
   default     = false
 }
 
-variable "random_certificate_suffix"
+variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool
   default     = false

--- a/test/setup/.gitignore
+++ b/test/setup/.gitignore
@@ -1,2 +1,3 @@
 terraform.tfvars
 source.sh
+terraform.lock.hcl

--- a/test/setup/make_source.sh
+++ b/test/setup/make_source.sh
@@ -21,4 +21,4 @@ echo "export TF_VAR_project_id='$project_id'" >> ../source.sh
 
 sa_json=$(terraform output sa_key)
 # shellcheck disable=SC2086
-echo "export SERVICE_ACCOUNT_JSON='$(echo $sa_json | base64 --decode)'" >> ../source.sh
+echo "export SERVICE_ACCOUNT_JSON='$(echo $sa_json | base64 -di)'" >> ../source.sh

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ variable "https_redirect" {
   default     = false
 }
 
-variable "random_certificate_suffix"
+variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -216,3 +216,9 @@ variable "https_redirect" {
   type        = bool
   default     = false
 }
+
+variable "random_certificate_suffix"
+  description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR implements a random_id suffix on the GCP managed SSL cert, as per the provider documentation . https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate

This will prevent Terraform trying to remove a certificate that is already in use, when it tries to replace it with a cert of the same name. Has been reported in several issues;
https://github.com/hashicorp/terraform/issues/10546
https://github.com/hashicorp/terraform-provider-google/issues/5356

Tested as working in two separate dev projects.