### PR TITLE
Add protocol support and set the default value to HTTP2

### DIFF
--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -32,6 +32,7 @@ module "lb-http" {
       enable_cdn                      = false
       custom_request_headers          = null
       security_policy                 = null
+      protocol                        = "HTTP2"
 
 
       log_config = {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -153,6 +153,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
   enable_cdn                      = lookup(each.value, "enable_cdn", false)
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
+  protocol                        = lookup(each.value, "protocol", "HTTP2")
 
   # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.
   security_policy = lookup(each.value, "security_policy") == "" ? null : (lookup(each.value, "security_policy") == null ? var.security_policy : each.value.security_policy)


### PR DESCRIPTION
GLB <> Cloud Run connection supports HTTP2 by default without requiring any special setup. It could be a good idea to enable it by default.