### PR TITLE
fix: Expose ipv6_enabled boolean flag as module output 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Current version is 3.0. Upgrade guides:
 | external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -29,6 +29,11 @@ output "external_ipv6_address" {
   value       = local.ipv6_address
 }
 
+output "ipv6_enabled" {
+  description = "Whether IPv6 configuration is enabled on this load-balancer"
+  value       = var.enable_ipv6
+}
+
 output "http_proxy" {
   description = "The HTTP proxy used by this module."
   value       = google_compute_target_http_proxy.default[*].self_link

--- a/examples/https-gke/README.md
+++ b/examples/https-gke/README.md
@@ -183,6 +183,6 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-gke/outputs.tf
+++ b/examples/https-gke/outputs.tf
@@ -19,5 +19,6 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-https.external_ipv6_address
+  value       = module.gce-lb-https.ipv6_enabled ? module.gce-lb-https.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }

--- a/examples/https-redirect/README.md
+++ b/examples/https-redirect/README.md
@@ -74,6 +74,6 @@ terraform destroy
 |------|-------------|
 | backend\_services | n/a |
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/https-redirect/outputs.tf
+++ b/examples/https-redirect/outputs.tf
@@ -19,7 +19,8 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-http.external_ipv6_address
+  value       = module.gce-lb-http.ipv6_enabled ? module.gce-lb-http.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }
 
 output "backend_services" {

--- a/examples/mig-nat-http-lb/README.md
+++ b/examples/mig-nat-http-lb/README.md
@@ -78,6 +78,6 @@ terraform destroy
 |------|-------------|
 | backend\_services | n/a |
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/mig-nat-http-lb/outputs.tf
+++ b/examples/mig-nat-http-lb/outputs.tf
@@ -19,7 +19,8 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-http.external_ipv6_address
+  value       = module.gce-lb-http.ipv6_enabled ? module.gce-lb-http.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }
 
 output "backend_services" {

--- a/examples/multi-backend-multi-mig-bucket-https-lb/README.md
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/README.md
@@ -105,11 +105,11 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | asset-url | n/a |
-| asset-url-ipv6 | n/a |
+| asset-url-ipv6 | The asset url over IPv6 address of the load-balancer, if enabled; else "undefined" |
 | group1\_region | n/a |
 | group2\_region | n/a |
 | group3\_region | n/a |
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/outputs.tf
@@ -31,7 +31,8 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-https.external_ipv6_address
+  value       = module.gce-lb-https.ipv6_enabled ? module.gce-lb-https.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }
 
 output "asset-url" {
@@ -39,5 +40,6 @@ output "asset-url" {
 }
 
 output "asset-url-ipv6" {
-  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
+  value       = module.gce-lb-https.ipv6_enabled ? "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg" : "undefined"
+  description = "The asset url over IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }

--- a/examples/multi-mig-http-lb/README.md
+++ b/examples/multi-mig-http-lb/README.md
@@ -102,6 +102,6 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-mig-http-lb/outputs.tf
+++ b/examples/multi-mig-http-lb/outputs.tf
@@ -19,5 +19,6 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-http.external_ipv6_address
+  value       = module.gce-lb-http.ipv6_enabled ? module.gce-lb-http.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }

--- a/examples/multiple-certs/README.md
+++ b/examples/multiple-certs/README.md
@@ -111,11 +111,11 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | asset-url | n/a |
-| asset-url-ipv6 | n/a |
+| asset-url-ipv6 | The asset url over IPv6 address of the load-balancer, if enabled; else "undefined" |
 | group1\_region | n/a |
 | group2\_region | n/a |
 | group3\_region | n/a |
 | load-balancer-ip | n/a |
-| load-balancer-ipv6 | n/a |
+| load-balancer-ipv6 | The IPv6 address of the load-balancer, if enabled; else "undefined" |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-certs/outputs.tf
+++ b/examples/multiple-certs/outputs.tf
@@ -31,7 +31,8 @@ output "load-balancer-ip" {
 }
 
 output "load-balancer-ipv6" {
-  value = module.gce-lb-https.external_ipv6_address
+  value       = module.gce-lb-https.ipv6_enabled ? module.gce-lb-https.external_ipv6_address : "undefined"
+  description = "The IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }
 
 output "asset-url" {
@@ -39,5 +40,6 @@ output "asset-url" {
 }
 
 output "asset-url-ipv6" {
-  value = "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg"
+  value       = module.gce-lb-https.ipv6_enabled ? "https://${module.gce-lb-https.external_ipv6_address}/assets/gcp-logo.svg" : "undefined"
+  description = "The asset url over IPv6 address of the load-balancer, if enabled; else \"undefined\""
 }

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -65,7 +65,7 @@ terraform destroy
 | Name | Description |
 |------|-------------|
 | external\_ip | The external IP assigned to the load balancer. |
-| external\_ipv6\_address | The external IPv6 address assigned to the load balancer. |
+| external\_ipv6\_address | The external IPv6 address assigned to the load balancer, if enabled; else "undefined" |
 | service\_project | The service project the load balancer is in. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/shared-vpc/outputs.tf
+++ b/examples/shared-vpc/outputs.tf
@@ -20,8 +20,8 @@ output "external_ip" {
 }
 
 output "external_ipv6_address" {
-  description = "The external IPv6 address assigned to the load balancer."
-  value       = module.gce-lb-http.external_ipv6_address
+  description = "The external IPv6 address assigned to the load balancer, if enabled; else \"undefined\""
+  value       = module.gce-lb-http.ipv6_enabled ? module.gce-lb-http.external_ipv6_address : "undefined"
 }
 
 output "service_project" {

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -139,6 +139,7 @@ Current version is 3.0. Upgrade guides:
 | external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/dynamic_backends/outputs.tf
+++ b/modules/dynamic_backends/outputs.tf
@@ -29,6 +29,11 @@ output "external_ipv6_address" {
   value       = local.ipv6_address
 }
 
+output "ipv6_enabled" {
+  description = "Whether IPv6 configuration is enabled on this load-balancer"
+  value       = var.enable_ipv6
+}
+
 output "http_proxy" {
   description = "The HTTP proxy used by this module."
   value       = google_compute_target_http_proxy.default[*].self_link

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -101,6 +101,7 @@ Current version is 3.0. Upgrade guides:
 | external\_ipv6\_address | The external IPv6 assigned to the global fowarding rule. |
 | http\_proxy | The HTTP proxy used by this module. |
 | https\_proxy | The HTTPS proxy used by this module. |
+| ipv6\_enabled | Whether IPv6 configuration is enabled on this load-balancer |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/serverless_negs/outputs.tf
+++ b/modules/serverless_negs/outputs.tf
@@ -29,6 +29,11 @@ output "external_ipv6_address" {
   value       = local.ipv6_address
 }
 
+output "ipv6_enabled" {
+  description = "Whether IPv6 configuration is enabled on this load-balancer"
+  value       = var.enable_ipv6
+}
+
 output "http_proxy" {
   description = "The HTTP proxy used by this module."
   value       = google_compute_target_http_proxy.default[*].self_link

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,11 @@ output "external_ipv6_address" {
   value       = local.ipv6_address
 }
 
+output "ipv6_enabled" {
+  description = "Whether IPv6 configuration is enabled on this load-balancer"
+  value       = var.enable_ipv6
+}
+
 output "http_proxy" {
   description = "The HTTP proxy used by this module."
   value       = google_compute_target_http_proxy.default[*].self_link


### PR DESCRIPTION
Expose the boolean flag `enable_ipv6` as an output from the module.

This is so that the consumers of the module can conditionally consume
the required IPv6 resources.

We expose it as an output variable `ipv6_enabled`.

Fixes #165.

Signed-off-by: Kunal Gangakhedkar <kunalg@hotstar.com>