### PR TITLE
Mark output derived from possible sensitive attribute as sensitive

### DIFF
--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -17,6 +17,7 @@
 output "backend_services" {
   description = "The backend service resources."
   value       = google_compute_backend_service.default
+  sensitive   = true // can contain sensitive iap_config
 }
 
 output "external_ip" {

--- a/modules/dynamic_backends/outputs.tf
+++ b/modules/dynamic_backends/outputs.tf
@@ -17,6 +17,7 @@
 output "backend_services" {
   description = "The backend service resources."
   value       = google_compute_backend_service.default
+  sensitive   = true // can contain sensitive iap_config
 }
 
 output "external_ip" {

--- a/modules/serverless_negs/outputs.tf
+++ b/modules/serverless_negs/outputs.tf
@@ -17,6 +17,7 @@
 output "backend_services" {
   description = "The backend service resources."
   value       = google_compute_backend_service.default
+  sensitive   = true // can contain sensitive iap_config
 }
 
 output "external_ip" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,6 +17,7 @@
 output "backend_services" {
   description = "The backend service resources."
   value       = google_compute_backend_service.default
+  sensitive   = true // can contain sensitive iap_config
 }
 
 output "external_ip" {


### PR DESCRIPTION
In never versions of terraform, such as 0.14 or 0.15, output values must be marked as sensitive, if they are derived from sensitive fields. This is the case for the `backend_services` output, because it can contain sensitive data (fields `oauth2_client_id` and `oauth2_client_secret` from `iap_config`.

This PR fixes the error:
```
Error: Output refers to sensitive values

  on .terraform/modules/lb-http/modules/serverless_negs/outputs.tf line 17:
  17: output "backend_services" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```

After applying this PR, the output generated by `terraform plan` will look like the following:
```
# module.lb-http.google_compute_backend_service.default["default"] will be created
  + resource "google_compute_backend_service" "default" {
      + connection_draining_timeout_sec = (sensitive)
      + creation_timestamp              = (known after apply)
      + enable_cdn                      = (sensitive)
      + fingerprint                     = (known after apply)
      + id                              = (known after apply)
      + load_balancing_scheme           = "EXTERNAL"
      + name                            = "hello-app-backend-default"
      + port_name                       = (known after apply)
      + project                         = "cloud-run-iap-terraform-demo-1"
      + protocol                        = (known after apply)
      + self_link                       = (known after apply)
      + session_affinity                = (known after apply)
      + timeout_sec                     = (known after apply)

      + backend {
          + balancing_mode  = "UTILIZATION"
          + capacity_scaler = 1
          + group           = (known after apply)
          + max_utilization = 0.8
        }

      + cdn_policy {
          + cache_mode                   = (known after apply)
          + client_ttl                   = (known after apply)
          + default_ttl                  = (known after apply)
          + max_ttl                      = (known after apply)
          + negative_caching             = (known after apply)
          + serve_while_stale            = (known after apply)
          + signed_url_cache_max_age_sec = (known after apply)

          + cache_key_policy {
              + include_host           = (known after apply)
              + include_protocol       = (known after apply)
              + include_query_string   = (known after apply)
              + query_string_blacklist = (known after apply)
              + query_string_whitelist = (known after apply)
            }

          + negative_caching_policy {
              + code = (known after apply)
              + ttl  = (known after apply)
            }
        }

      + iap {
          + oauth2_client_id            = (sensitive)
          + oauth2_client_secret        = (sensitive value)
          + oauth2_client_secret_sha256 = (sensitive value)
        }

      + log_config {
          + enable = (sensitive)
        }
    }
```

As you see the `iap` section will now have marked the values as `sensitive`.