### PR TITLE
Added region tag, module source, and version to Cloud Run example

### DIFF
--- a/examples/cloudrun/main.tf
+++ b/examples/cloudrun/main.tf
@@ -24,7 +24,7 @@ provider "google-beta" {
 
 # [START cloudloadbalancing_ext_http_cloudrun]
 module "lb-http" {
-  source  = "GoogleCloudPlatform/lb-http/google/modules/serverless_negs"
+  source = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version = "~> 5.1"
   name    = "tf-cr-lb"
   project = var.project_id

--- a/examples/cloudrun/main.tf
+++ b/examples/cloudrun/main.tf
@@ -24,7 +24,7 @@ provider "google-beta" {
 
 # [START cloudloadbalancing_ext_http_cloudrun]
 module "lb-http" {
-  source = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version = "~> 5.1"
   name    = "tf-cr-lb"
   project = var.project_id

--- a/examples/cloudrun/main.tf
+++ b/examples/cloudrun/main.tf
@@ -24,7 +24,7 @@ provider "google-beta" {
 
 # [START cloudloadbalancing_ext_http_cloudrun]
 module "lb-http" {
-  source  = "GoogleCloudPlatform/lb-http/google"
+  source  = "GoogleCloudPlatform/lb-http/google/modules/serverless_negs"
   version = "~> 5.1"
   name    = "tf-cr-lb"
   project = var.project_id

--- a/examples/cloudrun/main.tf
+++ b/examples/cloudrun/main.tf
@@ -22,8 +22,10 @@ provider "google-beta" {
   project = var.project_id
 }
 
+# [START cloudloadbalancing_ext_http_cloudrun]
 module "lb-http" {
-  source  = "../../modules/serverless_negs"
+  source  = "GoogleCloudPlatform/lb-http/google"
+  version = "~> 5.1"
   name    = "tf-cr-lb"
   project = var.project_id
 
@@ -88,3 +90,4 @@ resource "google_cloud_run_service_iam_member" "public-access" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+# [END cloudloadbalancing_ext_http_cloudrun]


### PR DESCRIPTION
Intending to add snippet to another standalone example page, similar to https://cloud.google.com/load-balancing/docs/terraform/ext-http-lb-gce-tf-module