### PR TITLE
Create the `random_id.certificate` resource only when needed.

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -116,7 +116,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
-  count       = var.random_certificate_suffix == true ? 1 : 0 
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -116,6 +116,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0 
   byte_length = 4
   prefix      = "${var.name}-cert-"
 

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0 
   byte_length = 4
   prefix      = "${var.name}-cert-"
 


### PR DESCRIPTION
The option to add a random prefix to the name of the managed certificate
was added as part of #160. When this option is disabled, the `random_id`
resource is still created, despite not being used anywhere. This could
cause confusion when looking at the output of `terraform plan`.

This PR makes the creation of that resource conditional on the
`random_certificate_suffix` flag. When the flag is set to `false`, v5.0
and v6.0 generate the same resources.