### PR TITLE
Create the `random_id.certificate` resource only when needed.

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -116,6 +116,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 
@@ -128,7 +129,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate[0].hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 
@@ -124,7 +125,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate[0].hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 
@@ -124,7 +125,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate[0].hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -112,6 +112,7 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "random_id" "certificate" {
+  count       = var.random_certificate_suffix == true ? 1 : 0
   byte_length = 4
   prefix      = "${var.name}-cert-"
 
@@ -124,7 +125,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
   provider = google-beta
   project  = var.project
   count    = var.ssl && length(var.managed_ssl_certificate_domains) > 0 && ! var.use_ssl_certificates ? 1 : 0
-  name     = var.random_certificate_suffix == true ? random_id.certificate.hex : "${var.name}-cert"
+  name     = var.random_certificate_suffix == true ? random_id.certificate[0].hex : "${var.name}-cert"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
The option to add a random prefix to the name of the managed certificate
was added as part of #160. When this option is disabled, the `random_id`
resource is still created, despite not being used anywhere. This could
cause confusion when looking at the output of `terraform plan`.

This PR makes the creation of that resource conditional on the
`random_certificate_suffix` flag. When the flag is set to `false`, v5.0
and v6.0 generate the same resources.

(I tried reopening the old PR, but it was not possible, sorry for the mess)