### PR TITLE
Added region tags and version for shared VPC LB example

### DIFF
--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -1,12 +1,17 @@
 # Shared VPC Example
 
-This example shows how to use this module in a Shared VPC setup. In a service project, it creates a global HTTP forwarding rule to forward traffic to an instance group. Meanwhile it ensures the host project has firewall rules in place to allow the health check ingress.
+This example shows how to use this module in a Shared VPC setup. In a service
+project, it creates a global external HTTP forwarding rule to forward traffic
+to an instance group. Meanwhile, it ensures the host project has firewall
+rules in place to allow the health check ingress.
 
 ## Usage
 
 ### Configure the module
 
-To connect your load balancer to a Shared VPC, you need to edit some inputs to match your environment. Copy `example.tfvars` into `terraform.tfvars` and update the [inputs](#inputs) to specify your desired Shared VPC network.
+To connect your load balancer to a Shared VPC, you need to edit some inputs
+to match your environment. Copy `example.tfvars` into `terraform.tfvars`
+and update the [inputs](#inputs) to specify your desired Shared VPC network.
 
 ```
 cp example.tfvars terraform.tfvars

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -24,8 +24,10 @@ provider "google-beta" {
   region  = var.region
 }
 
+# [START cloudloadbalancing_ext_http_gce_shared_vpc]
 module "gce-lb-http" {
-  source            = "../../"
+  source            = "GoogleCloudPlatform/lb-http/google"
+  version           = "~> 5.1"
   name              = "group-http-lb"
   project           = var.service_project
   target_tags       = ["allow-shared-vpc-mig"]
@@ -87,3 +89,4 @@ module "gce-lb-http" {
     }
   }
 }
+# [END cloudloadbalancing_ext_http_gce_shared_vpc]


### PR DESCRIPTION
Intending to add to this page:

https://cloud.google.com/load-balancing/docs/https/ext-http-lb-tf-module-examples