### PR TITLE
logconfig made optional

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -208,9 +208,12 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  log_config {
-    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
-    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+  dynamic "log_config" {
+    for_each = lookup(lookup(each.value, "log_config", {}), "enable", false) ? [1] : []
+    content {
+      enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
+      sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+    }
   }
 
   dynamic "iap" {

--- a/main.tf
+++ b/main.tf
@@ -195,9 +195,12 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  log_config {
-    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
-    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+  dynamic "log_config" {
+    for_each = lookup(lookup(each.value, "log_config", {}), "enable", false) ? [1] : []
+    content {
+      enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
+      sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+    }
   }
 
   dynamic "iap" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -195,9 +195,12 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  log_config {
-    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
-    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+  dynamic "log_config" {
+    for_each = lookup(lookup(each.value, "log_config", {}), "enable", false) ? [1] : []
+    content {
+      enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
+      sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+    }
   }
 
   dynamic "iap" {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -180,9 +180,12 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  log_config {
-    enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
-    sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+  dynamic "log_config" {
+    for_each = lookup(lookup(each.value, "log_config", {}), "enable", false) ? [1] : []
+    content {
+      enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
+      sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
+    }
   }
 
   dynamic "iap" {


### PR DESCRIPTION
Hello 👋 

I added the _dynamic_ to log_config in order to have the Terraform run without any message when the log_config is set like this:

```
      log_config = {
        enable      = false
        sample_rate = 0.0
      } 
```