### PR TITLE
fix: Modify the link to the diagram.png and the upgrade guide for 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ module "gce-lb-http" {
 
 **Figure 1.** *diagram of terraform resources*
 
-![architecture diagram](./diagram.png)
+![architecture diagram](/diagram.png)
 
 ## Version
 
 Current version is 3.0. Upgrade guides:
 
 * [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [2.X -> 3.0](/docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -141,7 +141,7 @@ module "lb-http" {
 
 **Figure 1.** *diagram of terraform resources*
 
-![architecture diagram](./diagram.png)
+![architecture diagram](/diagram.png)
 {% endif %}
 
 ## Version
@@ -149,7 +149,7 @@ module "lb-http" {
 Current version is 3.0. Upgrade guides:
 
 * [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [2.X -> 3.0](/docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -90,14 +90,14 @@ module "gce-lb-http" {
 
 **Figure 1.** *diagram of terraform resources*
 
-![architecture diagram](./diagram.png)
+![architecture diagram](/diagram.png)
 
 ## Version
 
 Current version is 3.0. Upgrade guides:
 
 * [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [2.X -> 3.0](/docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -63,7 +63,7 @@ module "lb-http" {
 Current version is 3.0. Upgrade guides:
 
 * [1.X -> 2.X](https://www.terraform.io/upgrade-guides/0-12.html)
-* [2.X -> 3.0](./docs/upgrading-v2.0.0-v3.0.0.md)
+* [2.X -> 3.0](/docs/upgrading-v2.0.0-v3.0.0.md)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs


### PR DESCRIPTION
Hello, both `modules/dynamic_backends/README.md` and `modules/serverless_negs/README.md` are generated from `autogen/README.md` when running `make build`. But the original `autogen/README.md` seems to suppose only `README.md` on the repository root. This causes the two broken links in two `README.md` under `modules/` directory.

You can see these broken links in the following page:

- [terraform-google-lb-http/modules/dynamic_backends at master · terraform-google-modules/terraform-google-lb-http](https://github.com/terraform-google-modules/terraform-google-lb-http/tree/master/modules/dynamic_backends#resources-created)
  - diagram image
  - link to the upgrade guide v3
- [terraform-google-lb-http/modules/serverless_negs at master · terraform-google-modules/terraform-google-lb-http](https://github.com/terraform-google-modules/terraform-google-lb-http/tree/master/modules/serverless_negs#version)
  - link to the upgrade guide v3

This PR fixes these two links by changing the relative link to the absolute link.

Thanks! 🙂 