### PR TITLE
Add https_redirect_response_code variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Current version is 3.0. Upgrade guides:
 | firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| https\_redirect\_response\_code | The HTTP status code to use for the HTTPS redirect. Must be one of: "MOVED\_PERMANENTLY\_DEFAULT", "FOUND", "SEE\_OTHER", "TEMPORARY\_REDIRECT", "PERMANENT\_REDIRECT". | `string` | `"MOVED_PERMANENTLY_DEFAULT"` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -153,7 +153,7 @@ resource "google_compute_url_map" "https_redirect" {
   name    = "${var.name}-https-redirect"
   default_url_redirect {
     https_redirect         = true
-    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    redirect_response_code = var.https_redirect_response_code
     strip_query            = false
   }
 }

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -231,6 +231,12 @@ variable "https_redirect" {
   default     = false
 }
 
+variable "https_redirect_response_code" {
+  type        = string
+  description = "The HTTP status code to use for the HTTPS redirect. Must be one of: \"MOVED_PERMANENTLY_DEFAULT\", \"FOUND\", \"SEE_OTHER\", \"TEMPORARY_REDIRECT\", \"PERMANENT_REDIRECT\"."
+  default     = "MOVED_PERMANENTLY_DEFAULT"
+}
+
 variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool

--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ resource "google_compute_url_map" "https_redirect" {
   name    = "${var.name}-https-redirect"
   default_url_redirect {
     https_redirect         = true
-    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    redirect_response_code = var.https_redirect_response_code
     strip_query            = false
   }
 }

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -116,6 +116,7 @@ Current version is 3.0. Upgrade guides:
 | firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| https\_redirect\_response\_code | The HTTP status code to use for the HTTPS redirect. Must be one of: "MOVED\_PERMANENTLY\_DEFAULT", "FOUND", "SEE\_OTHER", "TEMPORARY\_REDIRECT", "PERMANENT\_REDIRECT". | `string` | `"MOVED_PERMANENTLY_DEFAULT"` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -149,7 +149,7 @@ resource "google_compute_url_map" "https_redirect" {
   name    = "${var.name}-https-redirect"
   default_url_redirect {
     https_redirect         = true
-    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    redirect_response_code = var.https_redirect_response_code
     strip_query            = false
   }
 }

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -218,6 +218,12 @@ variable "https_redirect" {
   default     = false
 }
 
+variable "https_redirect_response_code" {
+  type        = string
+  description = "The HTTP status code to use for the HTTPS redirect. Must be one of: \"MOVED_PERMANENTLY_DEFAULT\", \"FOUND\", \"SEE_OTHER\", \"TEMPORARY_REDIRECT\", \"PERMANENT_REDIRECT\"."
+  default     = "MOVED_PERMANENTLY_DEFAULT"
+}
+
 variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -80,6 +80,7 @@ Current version is 3.0. Upgrade guides:
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
+| https\_redirect\_response\_code | The HTTP status code to use for the HTTPS redirect. Must be one of: "MOVED\_PERMANENTLY\_DEFAULT", "FOUND", "SEE\_OTHER", "TEMPORARY\_REDIRECT", "PERMANENT\_REDIRECT". | `string` | `"MOVED_PERMANENTLY_DEFAULT"` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -149,7 +149,7 @@ resource "google_compute_url_map" "https_redirect" {
   name    = "${var.name}-https-redirect"
   default_url_redirect {
     https_redirect         = true
-    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    redirect_response_code = var.https_redirect_response_code
     strip_query            = false
   }
 }

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -168,6 +168,12 @@ variable "https_redirect" {
   default     = false
 }
 
+variable "https_redirect_response_code" {
+  type        = string
+  description = "The HTTP status code to use for the HTTPS redirect. Must be one of: \"MOVED_PERMANENTLY_DEFAULT\", \"FOUND\", \"SEE_OTHER\", \"TEMPORARY_REDIRECT\", \"PERMANENT_REDIRECT\"."
+  default     = "MOVED_PERMANENTLY_DEFAULT"
+}
+
 variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,12 @@ variable "https_redirect" {
   default     = false
 }
 
+variable "https_redirect_response_code" {
+  type        = string
+  description = "The HTTP status code to use for the HTTPS redirect. Must be one of: \"MOVED_PERMANENTLY_DEFAULT\", \"FOUND\", \"SEE_OTHER\", \"TEMPORARY_REDIRECT\", \"PERMANENT_REDIRECT\"."
+  default     = "MOVED_PERMANENTLY_DEFAULT"
+}
+
 variable "random_certificate_suffix" {
   description = "Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert."
   type        = bool


### PR DESCRIPTION
Adds a `https_redirect_response_code` to allow the HTTP status code to be chosen for the HTTPS redirect. The variable defaults to "MOVED_PERMANENTLY_DEFAULT" so that there is no change in functionality unless a different value is explicitly set.

A use case for this is when you want the request method to be retained on the HTTPS request. 