### PR TITLE
use ubuntu 18 for mig2 and mig3 templates

### DIFF
--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -83,6 +83,8 @@ module "mig2_template" {
   }
   name_prefix    = "${var.network_name}-group2"
   startup_script = data.template_file.group2-startup-script.rendered
+  source_image_family  = "ubuntu-1804-lts"
+  source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group2",
     module.cloud-nat-group2.router_name
@@ -116,6 +118,8 @@ module "mig3_template" {
   }
   name_prefix    = "${var.network_name}-group3"
   startup_script = data.template_file.group3-startup-script.rendered
+  source_image_family  = "ubuntu-1804-lts"
+  source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group3",
     module.cloud-nat-group2.router_name

--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -81,8 +81,8 @@ module "mig2_template" {
     email  = ""
     scopes = ["cloud-platform"]
   }
-  name_prefix    = "${var.network_name}-group2"
-  startup_script = data.template_file.group2-startup-script.rendered
+  name_prefix          = "${var.network_name}-group2"
+  startup_script       = data.template_file.group2-startup-script.rendered
   source_image_family  = "ubuntu-1804-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
@@ -116,8 +116,8 @@ module "mig3_template" {
     email  = ""
     scopes = ["cloud-platform"]
   }
-  name_prefix    = "${var.network_name}-group3"
-  startup_script = data.template_file.group3-startup-script.rendered
+  name_prefix          = "${var.network_name}-group3"
+  startup_script       = data.template_file.group3-startup-script.rendered
   source_image_family  = "ubuntu-1804-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [


### PR DESCRIPTION
There's a Cloud Learning Services hands-on lab which follows this example and is experiencing issues. The mig2 and mig3 instances are failing their health checks and the application is unreachable at group2 and group3.

The current template defaults to a Centos7 image and the instances are hitting a file system error and failing to boot past emergency mode. Switching them to ubuntu 18 like mig1 resolves the issue. 