### PR TITLE
Expand url map functionality in serverless_negs

### DIFF
--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -92,6 +92,7 @@ Current version is 3.0. Upgrade guides:
 | ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
 | ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |
 | url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| url\_map\_spec | Specification for building a URL Map to created backend services. | <pre>map(object({<br>    hosts           = list(string)<br>    default_service = string<br>    rules = list(object({<br>      paths   = list(string)<br>      service = string<br>    }))<br>  }))</pre> | n/a | yes |
 | use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -137,11 +137,14 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 
 resource "google_compute_url_map" "default" {
-  project         = var.project
-  count           = var.create_url_map ? 1 : 0
-  name            = "${var.name}-url-map"
-  description     = "URL map for ${var.name}."
-  default_service = google_compute_backend_service.default[keys(var.backends)[0]].self_link
+  project     = var.project
+  count       = var.create_url_map ? 1 : 0
+  name        = "${var.name}-url-map"
+  description = "URL map for ${var.name}."
+  default_service = try(
+    google_compute_backend_service.default[var.url_map_spec.default_service].self_link,
+    google_compute_backend_service.default[keys(var.backends)[0]].self_link
+  )
 
   dynamic "host_rule" {
     for_each = { for i, rule in var.url_map_spec.host_rules : i => rule }

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -98,6 +98,7 @@ variable "url_map" {
 
 variable "url_map_spec" {
   type = object({
+    default_service = string
     host_rules = list(object({
       hosts        = list(string)
       path_matcher = string

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -96,6 +96,23 @@ variable "url_map" {
   default     = null
 }
 
+variable "url_map_spec" {
+  type = object({
+    host_rules = list(object({
+      hosts        = list(string)
+      path_matcher = string
+    }))
+    path_matchers = map(object({
+      default_service = string
+      rules = list(object({
+        paths   = list(string)
+        service = string
+      }))
+    }))
+  })
+  description = "Spec for building a URL Map. The first service in backends is also the default backend for whole the URL Map."
+}
+
 variable "http_forward" {
   description = "Set to `false` to disable HTTP port 80 forward"
   type        = bool


### PR DESCRIPTION
Previously, this module provided the option to either construct a
trivial url map which maps everything to a single backend OR pass in
a url map. The problem with passing in a url map is that the url map
depends on the backend services that are created in the serverless_negs
module which makes this approach unworkable.

This work adds the input variable `url_map_spec` which allows the
user to pass in a map of objects which are keyed on the same set
as the keys of the `backends` input variable.

This new variable enables the addition of host_rule/path_matcher pairs
to the google_compute_url_map block with a list of path_rules for each
of these pairs.