### PR TITLE
Adds support for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -31,55 +31,67 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
+  provider   = google-beta
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
   name       = var.name
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
+  provider   = google-beta
   project    = var.project
   count      = var.ssl ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default" {
+  provider   = google-beta
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
   ip_version = "IPV4"
+  labels     = var.labels
 }
 ### IPv4 block ###
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default_ipv6" {
+  provider   = google-beta
   count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"
+  labels     = var.labels
 }
 ### IPv6 block ###
 

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -236,3 +236,9 @@ variable "random_certificate_suffix" {
   type        = bool
   default     = false
 }
+
+variable "labels" {
+  description = "The labels to attach to resources created by this module"
+  type        = map(string)
+  default     = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -27,55 +27,67 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
+  provider   = google-beta
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
   name       = var.name
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
+  provider   = google-beta
   project    = var.project
   count      = var.ssl ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default" {
+  provider   = google-beta
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
   ip_version = "IPV4"
+  labels     = var.labels
 }
 ### IPv4 block ###
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default_ipv6" {
+  provider   = google-beta
   count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"
+  labels     = var.labels
 }
 ### IPv6 block ###
 

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -117,6 +117,7 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -27,55 +27,67 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
+  provider   = google-beta
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
   name       = var.name
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
+  provider   = google-beta
   project    = var.project
   count      = var.ssl ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default" {
+  provider   = google-beta
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
   ip_version = "IPV4"
+  labels     = var.labels
 }
 ### IPv4 block ###
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default_ipv6" {
+  provider   = google-beta
   count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"
+  labels     = var.labels
 }
 ### IPv6 block ###
 

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -223,3 +223,9 @@ variable "random_certificate_suffix" {
   type        = bool
   default     = false
 }
+
+variable "labels" {
+  description = "The labels to attach to resources created by this module"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -81,6 +81,7 @@ Current version is 3.0. Upgrade guides:
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
+| labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -27,55 +27,67 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
+  provider   = google-beta
   project    = var.project
   count      = local.create_http_forward ? 1 : 0
   name       = var.name
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
+  provider   = google-beta
   project    = var.project
   count      = var.ssl ? 1 : 0
   name       = "${var.name}-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default" {
+  provider   = google-beta
   count      = var.create_address ? 1 : 0
   project    = var.project
   name       = "${var.name}-address"
   ip_version = "IPV4"
+  labels     = var.labels
 }
 ### IPv4 block ###
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
   name       = "${var.name}-ipv6-http"
   target     = google_compute_target_http_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "80"
+  labels     = var.labels
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  provider   = google-beta
   project    = var.project
   count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
   name       = "${var.name}-ipv6-https"
   target     = google_compute_target_https_proxy.default[0].self_link
   ip_address = local.ipv6_address
   port_range = "443"
+  labels     = var.labels
 }
 
 resource "google_compute_global_address" "default_ipv6" {
+  provider   = google-beta
   count      = (var.enable_ipv6 && var.create_ipv6_address) ? 1 : 0
   project    = var.project
   name       = "${var.name}-ipv6-address"
   ip_version = "IPV6"
+  labels     = var.labels
 }
 ### IPv6 block ###
 

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -173,3 +173,9 @@ variable "random_certificate_suffix" {
   type        = bool
   default     = false
 }
+
+variable "labels" {
+  description = "The labels to attach to resources created by this module"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,9 @@ variable "random_certificate_suffix" {
   type        = bool
   default     = false
 }
+
+variable "labels" {
+  description = "The labels to attach to resources created by this module"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Adds labels to `google_compute_global_forwarding_rule` and `google_compute_global_address` resources.

Labels on these resources require the `google-beta` provider: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule#labels