### PR TITLE
Enable creation of types of HTTPS Load Balancers other than classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Current version is 3.0. Upgrade guides:
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
+| load\_balancing\_scheme | Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL\_MANAGED, or INTERNAL\_SELF\_MANAGED.  Defaults to EXTERNAL. | `string` | `"EXTERNAL"` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -31,25 +31,27 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
-  provider   = google-beta
-  project    = var.project
-  count      = local.create_http_forward ? 1 : 0
-  name       = var.name
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = local.create_http_forward ? 1 : 0
+  name                  = var.name
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider   = google-beta
-  project    = var.project
-  count      = var.ssl ? 1 : 0
-  name       = "${var.name}-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = var.ssl ? 1 : 0
+  name                  = "${var.name}-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default" {
@@ -64,25 +66,27 @@ resource "google_compute_global_address" "default" {
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
-  name       = "${var.name}-ipv6-http"
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
+  name                  = "${var.name}-ipv6-http"
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
-  name       = "${var.name}-ipv6-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && var.ssl) ? 1 : 0
+  name                  = "${var.name}-ipv6-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default_ipv6" {
@@ -174,17 +178,18 @@ resource "google_compute_backend_service" "default" {
   provider = google-beta
   for_each = var.backends
 
-  project = var.project
-  name    = "${var.name}-backend-${each.key}"
+  project               = var.project
+  name                  = "${var.name}-backend-${each.key}"
+  load_balancing_scheme = var.load_balancing_scheme
 
   {% if not serverless %}{# not necessary for serverless as default port_name=http, protocol=HTTP #}
-  port_name                       = each.value.port_name
-  protocol                        = each.value.protocol
+  port_name = each.value.port_name
+  protocol  = each.value.protocol
   {% endif %}
 
   {% if not serverless %}
     {# Limitation: Timeout sec is not supported for a backend service with Serverless network endpoint groups. #}
-    timeout_sec                     = lookup(each.value, "timeout_sec", null)
+  timeout_sec                     = lookup(each.value, "timeout_sec", null)
   {% endif %}
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)
@@ -192,9 +197,9 @@ resource "google_compute_backend_service" "default" {
   custom_request_headers          = lookup(each.value, "custom_request_headers", [])
   custom_response_headers         = lookup(each.value, "custom_response_headers", [])
   {% if not serverless %}{# doesn't apply to serverless NEGs #}
-    health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
-    session_affinity                = lookup(each.value, "session_affinity", null)
-    affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
+  health_checks                   = lookup(each.value, "health_check", null) == null ? null : [google_compute_health_check.default[each.key].self_link]
+  session_affinity                = lookup(each.value, "session_affinity", null)
+  affinity_cookie_ttl_sec         = lookup(each.value, "affinity_cookie_ttl_sec", null)
   {% endif %}
 
   # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -242,3 +242,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "load_balancing_scheme" {
+  description = "Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL_MANAGED, or INTERNAL_SELF_MANAGED.  Defaults to EXTERNAL."
+  type        = string
+  default     = "EXTERNAL"
+}

--- a/main.tf
+++ b/main.tf
@@ -27,25 +27,27 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
-  provider   = google-beta
-  project    = var.project
-  count      = local.create_http_forward ? 1 : 0
-  name       = var.name
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = local.create_http_forward ? 1 : 0
+  name                  = var.name
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider   = google-beta
-  project    = var.project
-  count      = var.ssl ? 1 : 0
-  name       = "${var.name}-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = var.ssl ? 1 : 0
+  name                  = "${var.name}-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default" {
@@ -60,25 +62,27 @@ resource "google_compute_global_address" "default" {
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
-  name       = "${var.name}-ipv6-http"
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
+  name                  = "${var.name}-ipv6-http"
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
-  name       = "${var.name}-ipv6-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && var.ssl) ? 1 : 0
+  name                  = "${var.name}-ipv6-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default_ipv6" {
@@ -170,8 +174,9 @@ resource "google_compute_backend_service" "default" {
   provider = google-beta
   for_each = var.backends
 
-  project = var.project
-  name    = "${var.name}-backend-${each.key}"
+  project               = var.project
+  name                  = "${var.name}-backend-${each.key}"
+  load_balancing_scheme = var.load_balancing_scheme
 
   port_name = each.value.port_name
   protocol  = each.value.protocol

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -118,6 +118,7 @@ Current version is 3.0. Upgrade guides:
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
+| load\_balancing\_scheme | Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL\_MANAGED, or INTERNAL\_SELF\_MANAGED.  Defaults to EXTERNAL. | `string` | `"EXTERNAL"` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -27,25 +27,27 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
-  provider   = google-beta
-  project    = var.project
-  count      = local.create_http_forward ? 1 : 0
-  name       = var.name
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = local.create_http_forward ? 1 : 0
+  name                  = var.name
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider   = google-beta
-  project    = var.project
-  count      = var.ssl ? 1 : 0
-  name       = "${var.name}-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = var.ssl ? 1 : 0
+  name                  = "${var.name}-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default" {
@@ -60,25 +62,27 @@ resource "google_compute_global_address" "default" {
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
-  name       = "${var.name}-ipv6-http"
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
+  name                  = "${var.name}-ipv6-http"
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
-  name       = "${var.name}-ipv6-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && var.ssl) ? 1 : 0
+  name                  = "${var.name}-ipv6-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default_ipv6" {
@@ -170,8 +174,9 @@ resource "google_compute_backend_service" "default" {
   provider = google-beta
   for_each = var.backends
 
-  project = var.project
-  name    = "${var.name}-backend-${each.key}"
+  project               = var.project
+  name                  = "${var.name}-backend-${each.key}"
+  load_balancing_scheme = var.load_balancing_scheme
 
   port_name = each.value.port_name
   protocol  = each.value.protocol

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -229,3 +229,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "load_balancing_scheme" {
+  description = "Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL_MANAGED, or INTERNAL_SELF_MANAGED.  Defaults to EXTERNAL."
+  type        = string
+  default     = "EXTERNAL"
+}

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -82,6 +82,7 @@ Current version is 3.0. Upgrade guides:
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
+| load\_balancing\_scheme | Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL\_MANAGED, or INTERNAL\_SELF\_MANAGED.  Defaults to EXTERNAL. | `string` | `"EXTERNAL"` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` and `use_ssl_certificates` set to `false`. | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `null` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -27,25 +27,27 @@ locals {
 
 ### IPv4 block ###
 resource "google_compute_global_forwarding_rule" "http" {
-  provider   = google-beta
-  project    = var.project
-  count      = local.create_http_forward ? 1 : 0
-  name       = var.name
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = local.create_http_forward ? 1 : 0
+  name                  = var.name
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider   = google-beta
-  project    = var.project
-  count      = var.ssl ? 1 : 0
-  name       = "${var.name}-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = var.ssl ? 1 : 0
+  name                  = "${var.name}-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default" {
@@ -60,25 +62,27 @@ resource "google_compute_global_address" "default" {
 
 ### IPv6 block ###
 resource "google_compute_global_forwarding_rule" "http_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
-  name       = "${var.name}-ipv6-http"
-  target     = google_compute_target_http_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "80"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && local.create_http_forward) ? 1 : 0
+  name                  = "${var.name}-ipv6-http"
+  target                = google_compute_target_http_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "80"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
-  provider   = google-beta
-  project    = var.project
-  count      = (var.enable_ipv6 && var.ssl) ? 1 : 0
-  name       = "${var.name}-ipv6-https"
-  target     = google_compute_target_https_proxy.default[0].self_link
-  ip_address = local.ipv6_address
-  port_range = "443"
-  labels     = var.labels
+  provider              = google-beta
+  project               = var.project
+  count                 = (var.enable_ipv6 && var.ssl) ? 1 : 0
+  name                  = "${var.name}-ipv6-https"
+  target                = google_compute_target_https_proxy.default[0].self_link
+  ip_address            = local.ipv6_address
+  port_range            = "443"
+  labels                = var.labels
+  load_balancing_scheme = var.load_balancing_scheme
 }
 
 resource "google_compute_global_address" "default_ipv6" {
@@ -170,8 +174,9 @@ resource "google_compute_backend_service" "default" {
   provider = google-beta
   for_each = var.backends
 
-  project = var.project
-  name    = "${var.name}-backend-${each.key}"
+  project               = var.project
+  name                  = "${var.name}-backend-${each.key}"
+  load_balancing_scheme = var.load_balancing_scheme
 
 
   description                     = lookup(each.value, "description", null)

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -179,3 +179,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "load_balancing_scheme" {
+  description = "Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL_MANAGED, or INTERNAL_SELF_MANAGED.  Defaults to EXTERNAL."
+  type        = string
+  default     = "EXTERNAL"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -229,3 +229,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "load_balancing_scheme" {
+  description = "Scheme for load balancer backend and forwarding rule, can be EXTERNAL, EXTERNAL_MANAGED, or INTERNAL_SELF_MANAGED.  Defaults to EXTERNAL."
+  type        = string
+  default     = "EXTERNAL"
+}


### PR DESCRIPTION
This change set introduces load_balancing_scheme with a default value of EXTERNAL to maintain identical module behavior.  This allows the introduction of examples and tests for Envoy-based EXTERNAL_MANAGED and INTERNAL_SELF_MANAGED global load balancers.