### PR TITLE
fix: plumb backend values, upgrade guide

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -183,10 +183,8 @@ resource "google_compute_backend_service" "default" {
 
   load_balancing_scheme = var.load_balancing_scheme
 
-  {% if not serverless %}{# not necessary for serverless as default port_name=http, protocol=HTTP #}
   port_name = lookup(each.value, "port_name", "http")
   protocol  = lookup(each.value, "protocol", "HTTP")
-  {% endif %}
 
   {% if not serverless %}
   {# Limitation: Timeout sec is not supported for a backend service with Serverless network endpoint groups. #}

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -14,6 +14,9 @@
 
 timeout: 3600s
 steps:
+- id: swap-module-refs
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && module-swapper']
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']

--- a/docs/upgrading_to_v7.0.md
+++ b/docs/upgrading_to_v7.0.md
@@ -10,7 +10,7 @@ The v7.0 release contains backwards-incompatible changes to the backend config.
   module "gce-lb-http" {
     source            = "GoogleCloudPlatform/lb-http/google"
 -   version           = "~> 6.3.0"
-+   version           = "~> 7.0.0"
++   version           = "~> 7.0"
 
     backends = {
       default = {
@@ -30,7 +30,7 @@ To use the default value (`http`), specify `null`.
   module "gce-lb-http" {
     source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
 -   version           = "~> 6.3.0"
-+   version           = "~> 7.0.0"
++   version           = "~> 7.0"
 
     backends = {
       default = {

--- a/docs/upgrading_to_v7.0.md
+++ b/docs/upgrading_to_v7.0.md
@@ -1,0 +1,43 @@
+# Upgrading to v7.0
+
+The v7.0 release contains backwards-incompatible changes to the backend config.
+
+## Added support for `compression_mode`.
+
+`compression_mode` must now be specified for backends. To use the default value, specify `null`.
+
+```diff
+  module "gce-lb-http" {
+    source            = "GoogleCloudPlatform/lb-http/google"
+-   version           = "~> 6.3.0"
++   version           = "~> 7.0.0"
+
+    backends = {
+      default = {
++       compression_mode = null
+...
+      }
+    }
+  }
+```
+
+## Added support for `port` and `protocol` in `serverless_negs` module.
+
+`port` and `protocol` must now be specified for backends in `serverless_negs`.
+To use the default value (`http`), specify `null`.
+
+```diff
+  module "gce-lb-http" {
+    source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+-   version           = "~> 6.3.0"
++   version           = "~> 7.0.0"
+
+    backends = {
+      default = {
++       port     = null
++       protocol = null
+...
+      }
+    }
+  }
+```

--- a/examples/cloudrun/main.tf
+++ b/examples/cloudrun/main.tf
@@ -56,6 +56,9 @@ module "lb-http" {
         enable      = false
         sample_rate = null
       }
+      protocol         = null
+      port_name        = null
+      compression_mode = null
     }
   }
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   title: Global HTTP Load Balancer Terraform Module
   source:
-    repo: https://github.com/terraform-google-modules/terraform-google-lb-http.git
+    repo: https://github.com/terraform-google-modules/terraform-google-lb-http
     sourceType: git
   version: 6.3.0
   actuationTool:
@@ -116,6 +116,10 @@ spec:
     required: true
   - name: certificate
     description: Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty.
+    type: string
+    required: false
+  - name: certificate_map
+    description: Certificate Map ID in format projects/{project}/locations/global/certificateMaps/{name}. Identifies a certificate map associated with the given target proxy
     type: string
     required: false
   - name: create_address

--- a/modules/dynamic_backends/metadata.yaml
+++ b/modules/dynamic_backends/metadata.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   title: Global HTTP Load Balancer Terraform Module
   source:
-    repo: https://github.com/terraform-google-modules/terraform-google-lb-http.git
+    repo: https://github.com/terraform-google-modules/terraform-google-lb-http
     sourceType: git
   version: 6.3.0
   actuationTool:
@@ -111,6 +111,10 @@ spec:
     required: true
   - name: certificate
     description: Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty.
+    type: string
+    required: false
+  - name: certificate_map
+    description: Certificate Map ID in format projects/{project}/locations/global/certificateMaps/{name}. Identifies a certificate map associated with the given target proxy
     type: string
     required: false
   - name: create_address

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -180,6 +180,8 @@ resource "google_compute_backend_service" "default" {
 
   load_balancing_scheme = var.load_balancing_scheme
 
+  port_name = lookup(each.value, "port_name", "http")
+  protocol  = lookup(each.value, "protocol", "HTTP")
 
   description                     = lookup(each.value, "description", null)
   connection_draining_timeout_sec = lookup(each.value, "connection_draining_timeout_sec", null)

--- a/modules/serverless_negs/metadata.yaml
+++ b/modules/serverless_negs/metadata.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   title: Global HTTP Load Balancer Terraform Module for Serverless NEGs
   source:
-    repo: https://github.com/terraform-google-modules/terraform-google-lb-http.git
+    repo: https://github.com/terraform-google-modules/terraform-google-lb-http
     sourceType: git
   version: 6.3.0
   actuationTool:
@@ -86,6 +86,10 @@ spec:
     required: true
   - name: certificate
     description: Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty.
+    type: string
+    required: false
+  - name: certificate_map
+    description: Certificate Map ID in format projects/{project}/locations/global/certificateMaps/{name}. Identifies a certificate map associated with the given target proxy
     type: string
     required: false
   - name: create_address


### PR DESCRIPTION
- Looks like we forgot to plumb the new values we added in https://github.com/terraform-google-modules/terraform-google-lb-http/pull/287 to the resource
- Adds an upgrade guide
 