### PR TITLE
fix: Clarify the usage of `address` and `create_address`

### DIFF
--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -32,7 +32,7 @@ variable "create_address" {
 
 variable "address" {
   type        = string
-  description = "Existing IPv4 address to use (the actual IP address value)"
+  description = "Existing IPv4 address to use (the actual IP address value). Ignored unless \"create_address\" is set to \"false\"."
   default     = null
 }
 


### PR DESCRIPTION
This PR updates the docs to clarify that setting the value of `address` won't have any effect unless `create_address` is set to `false`. I learned it the hard way by spending hours waiting for the SSL certificate activation only to find out the provided `address` was ignored 😬  

Also, would the automation re-generate the Readme automatically on merge, or should I run the make script? Sorry if I did the wrong thing, this wasn't clear from the contribution guidelines.