### PR TITLE
fix: Invalid variable name in outlier_detection block

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -308,10 +308,10 @@ resource "google_compute_backend_service" "default" {
       }
 
       dynamic "interval" {
-        for_each = each.value.outlier_detection.cache_key_policy != null ? [1] : []
+        for_each = each.value.outlier_detection.interval != null ? [1] : []
         content {
-          seconds = each.value.outlier_detection.cache_key_policy.seconds
-          nanos   = each.value.outlier_detection.cache_key_policy.nanos
+          seconds = each.value.outlier_detection.interval.seconds
+          nanos   = each.value.outlier_detection.interval.nanos
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -299,10 +299,10 @@ resource "google_compute_backend_service" "default" {
       }
 
       dynamic "interval" {
-        for_each = each.value.outlier_detection.cache_key_policy != null ? [1] : []
+        for_each = each.value.outlier_detection.interval != null ? [1] : []
         content {
-          seconds = each.value.outlier_detection.cache_key_policy.seconds
-          nanos   = each.value.outlier_detection.cache_key_policy.nanos
+          seconds = each.value.outlier_detection.interval.seconds
+          nanos   = each.value.outlier_detection.interval.nanos
         }
       }
     }

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -299,10 +299,10 @@ resource "google_compute_backend_service" "default" {
       }
 
       dynamic "interval" {
-        for_each = each.value.outlier_detection.cache_key_policy != null ? [1] : []
+        for_each = each.value.outlier_detection.interval != null ? [1] : []
         content {
-          seconds = each.value.outlier_detection.cache_key_policy.seconds
-          nanos   = each.value.outlier_detection.cache_key_policy.nanos
+          seconds = each.value.outlier_detection.interval.seconds
+          nanos   = each.value.outlier_detection.interval.nanos
         }
       }
     }

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -287,10 +287,10 @@ resource "google_compute_backend_service" "default" {
       }
 
       dynamic "interval" {
-        for_each = each.value.outlier_detection.cache_key_policy != null ? [1] : []
+        for_each = each.value.outlier_detection.interval != null ? [1] : []
         content {
-          seconds = each.value.outlier_detection.cache_key_policy.seconds
-          nanos   = each.value.outlier_detection.cache_key_policy.nanos
+          seconds = each.value.outlier_detection.interval.seconds
+          nanos   = each.value.outlier_detection.interval.nanos
         }
       }
     }


### PR DESCRIPTION
This PR fixes a previous commit of mine that used the wrong nested variable in a `dynamic` block. The `cache_key_policy` inside the `outlier_detection` should be `interval` instead.