### PR TITLE
feat: support google_compute_target_https_proxy.server_tls_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ module "gce-lb-http" {
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |
 | random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
 | security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| server\_tls\_policy | A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic | `string` | `null` | no |
 | ssl | Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map` | `bool` | `false` | no |
 | ssl\_certificates | SSL cert self\_link list. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,10 +119,11 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
-  certificate_map  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy       = var.ssl_policy
-  quic_override    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  ssl_certificates  = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
+  certificate_map   = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  ssl_policy        = var.ssl_policy
+  server_tls_policy = var.server_tls_policy
+  quic_override     = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -263,6 +263,12 @@ variable "ssl_policy" {
   default     = null
 }
 
+variable "server_tls_policy" {
+  type        = string
+  description = "A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic"
+  default     = null
+}
+
 variable "quic" {
   type        = bool
   description = "Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only."

--- a/main.tf
+++ b/main.tf
@@ -117,10 +117,11 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
-  certificate_map  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy       = var.ssl_policy
-  quic_override    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  ssl_certificates  = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
+  certificate_map   = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  ssl_policy        = var.ssl_policy
+  server_tls_policy = var.server_tls_policy
+  quic_override     = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -111,6 +111,7 @@ module "gce-lb-http" {
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |
 | random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
 | security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| server\_tls\_policy | A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic | `string` | `null` | no |
 | ssl | Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map` | `bool` | `false` | no |
 | ssl\_certificates | SSL cert self\_link list. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -117,10 +117,11 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
-  certificate_map  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy       = var.ssl_policy
-  quic_override    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  ssl_certificates  = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
+  certificate_map   = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  ssl_policy        = var.ssl_policy
+  server_tls_policy = var.server_tls_policy
+  quic_override     = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -250,6 +250,12 @@ variable "ssl_policy" {
   default     = null
 }
 
+variable "server_tls_policy" {
+  type        = string
+  description = "A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic"
+  default     = null
+}
+
 variable "quic" {
   type        = bool
   description = "Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only."

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -94,6 +94,7 @@ module "lb-http" {
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |
 | random\_certificate\_suffix | Bool to enable/disable random certificate name generation. Set and keep this to true if you need to change the SSL cert. | `bool` | `false` | no |
 | security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `null` | no |
+| server\_tls\_policy | A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic | `string` | `null` | no |
 | ssl | Set to `true` to enable SSL support. If `true` then at least one of these are required: 1) `ssl_certificates` OR 2) `create_ssl_certificate` set to `true` and `private_key/certificate` OR  3) `managed_ssl_certificate_domains`, OR 4) `certificate_map` | `bool` | `false` | no |
 | ssl\_certificates | SSL cert self\_link list. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | ssl\_policy | Selfink to SSL Policy | `string` | `null` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -116,10 +116,11 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
-  certificate_map  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy       = var.ssl_policy
-  quic_override    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  ssl_certificates  = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, google_compute_managed_ssl_certificate.default.*.self_link, ), )
+  certificate_map   = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  ssl_policy        = var.ssl_policy
+  server_tls_policy = var.server_tls_policy
+  quic_override     = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -199,6 +199,12 @@ variable "ssl_policy" {
   default     = null
 }
 
+variable "server_tls_policy" {
+  type        = string
+  description = "A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic"
+  default     = null
+}
+
 variable "quic" {
   type        = bool
   description = "Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only."

--- a/variables.tf
+++ b/variables.tf
@@ -250,6 +250,12 @@ variable "ssl_policy" {
   default     = null
 }
 
+variable "server_tls_policy" {
+  type        = string
+  description = "A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic"
+  default     = null
+}
+
 variable "quic" {
   type        = bool
   description = "Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only."


### PR DESCRIPTION
Add support for optionally supplying a `server_tls_policy` argument to be attached to the `google_compute_target_https_proxy` resource.
My goal is to allow configuration of [Mutual TLS](https://cloud.google.com/load-balancing/docs/mtls) for LBs managed by this module.

I did see the existing open PR https://github.com/terraform-google-modules/terraform-google-lb-http/pull/387 but it's been a few days with no response to the request for changes and I'm keen to use this functionality 🙂
If desired, I've made a start at an example of using this new argument ( largely to validate the configuration with `make docker_test_lint`): https://github.com/cysp/terraform-google-lb-http/compare/feat/server-tls-policy...cysp:terraform-google-lb-http:feat/server-tls-policy-example
