### PR TITLE
feat: Add internal lbs to schemes, and add docs.

### DIFF
--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -85,10 +85,10 @@ module "lb-http" {
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |
-| load\_balancing\_scheme | Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL\_MANAGED for Envoy-based load balancer, and INTERNAL\_SELF\_MANAGED for traffic director) | `string` | `"EXTERNAL"` | no |
+| load\_balancing\_scheme | Load balancing scheme type (EXTERNAL for classic external load balancer, EXTERNAL\_MANAGED for Envoy-based load balancer, INTERNAL for Internal passthrough Network Load Balancer ,INTERNAL\_MANAGED for Crossregion internal Application Load Balancer, and INTERNAL\_SELF\_MANAGED for traffic director) | `string` | `"EXTERNAL"` | no |
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| network | Network for INTERNAL\_SELF\_MANAGED load balancing scheme | `string` | `"default"` | no |
+| network | Network for INTERNAL, INTERNAL\_MANAGED, INTERNAL\_SELF\_MANAGED  load balancing scheme | `string` | `"default"` | no |
 | private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
 | project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -23,7 +23,7 @@ locals {
   create_http_forward = var.http_forward || var.https_redirect
 
 
-  is_internal      = var.load_balancing_scheme == "INTERNAL_SELF_MANAGED"
+  is_internal      = var.load_balancing_scheme == "INTERNAL_SELF_MANAGED" || var.load_balancing_scheme == "INTERNAL_MANAGED" || var.load_balancing_scheme == "INTERNAL"
   internal_network = local.is_internal ? var.network : null
 }
 


### PR DESCRIPTION
Hey, I had a bug where i could not create an internal load balancer because of the `is_internal` condition.

I added some more internal load balancer type to the project according to https://cloud.google.com/load-balancing/docs/choosing-load-balancer.

Please let me know if something is wrong. I would gladely update this.

Thanks for the work