### PR TITLE
feat: Allow specifying HTTP and HTTPS port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ module "gce-lb-http" {
 | firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| http\_port | The port for the HTTP load balancer | `number` | `80` | no |
+| https\_port | The port for the HTTPS load balancer | `number` | `443` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -38,7 +38,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   name                  = var.name
   target                = google_compute_target_http_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "80"
+  port_range            = var.http_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
@@ -51,7 +51,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   name                  = "${var.name}-https"
   target                = google_compute_target_https_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "443"
+  port_range            = var.https_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -317,3 +317,23 @@ variable "server_tls_policy" {
   type        = string
   default     = null
 }
+
+variable "http_port" {
+  description = "The port for the HTTP load balancer"
+  type        = number
+  default     = 80
+  validation {
+    condition     = var.http_port >= 1 && var.http_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}
+
+variable "https_port" {
+  description = "The port for the HTTPS load balancer"
+  type        = number
+  default     = 443
+  validation {
+    condition     = var.https_port >= 1 && var.https_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   name                  = var.name
   target                = google_compute_target_http_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "80"
+  port_range            = var.http_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
@@ -49,7 +49,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   name                  = "${var.name}-https"
   target                = google_compute_target_https_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "443"
+  port_range            = var.https_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -99,6 +99,8 @@ module "gce-lb-http" {
 | firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| http\_port | The port for the HTTP load balancer | `number` | `80` | no |
+| https\_port | The port for the HTTPS load balancer | `number` | `443` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -36,7 +36,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   name                  = var.name
   target                = google_compute_target_http_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "80"
+  port_range            = var.http_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
@@ -49,7 +49,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   name                  = "${var.name}-https"
   target                = google_compute_target_https_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "443"
+  port_range            = var.https_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -304,3 +304,23 @@ variable "server_tls_policy" {
   type        = string
   default     = null
 }
+
+variable "http_port" {
+  description = "The port for the HTTP load balancer"
+  type        = number
+  default     = 80
+  validation {
+    condition     = var.http_port >= 1 && var.http_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}
+
+variable "https_port" {
+  description = "The port for the HTTPS load balancer"
+  type        = number
+  default     = 443
+  validation {
+    condition     = var.https_port >= 1 && var.https_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -82,6 +82,8 @@ module "lb-http" {
 | edge\_security\_policy | The resource URL for the edge security policy to associate with the backend service | `string` | `null` | no |
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| http\_port | The port for the HTTP load balancer | `number` | `80` | no |
+| https\_port | The port for the HTTPS load balancer | `number` | `443` | no |
 | https\_redirect | Set to `true` to enable https redirect on the lb. | `bool` | `false` | no |
 | ipv6\_address | An existing IPv6 address to use (the actual IP address value) | `string` | `null` | no |
 | labels | The labels to attach to resources created by this module | `map(string)` | `{}` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -35,7 +35,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   name                  = var.name
   target                = google_compute_target_http_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "80"
+  port_range            = var.http_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
@@ -48,7 +48,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   name                  = "${var.name}-https"
   target                = google_compute_target_https_proxy.default[0].self_link
   ip_address            = local.address
-  port_range            = "443"
+  port_range            = var.https_port
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -253,3 +253,23 @@ variable "server_tls_policy" {
   type        = string
   default     = null
 }
+
+variable "http_port" {
+  description = "The port for the HTTP load balancer"
+  type        = number
+  default     = 80
+  validation {
+    condition     = var.http_port >= 1 && var.http_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}
+
+variable "https_port" {
+  description = "The port for the HTTPS load balancer"
+  type        = number
+  default     = 443
+  validation {
+    condition     = var.https_port >= 1 && var.https_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -304,3 +304,15 @@ variable "server_tls_policy" {
   type        = string
   default     = null
 }
+
+variable "http_port" {
+  description = "The port for the HTTP load balancer"
+  type        = number
+  default     = 80
+}
+
+variable "https_port" {
+  description = "The port for the HTTPS load balancer"
+  type        = number
+  default     = 443
+}

--- a/variables.tf
+++ b/variables.tf
@@ -309,10 +309,18 @@ variable "http_port" {
   description = "The port for the HTTP load balancer"
   type        = number
   default     = 80
+  validation {
+    condition     = var.http_port >= 1 && var.http_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
 }
 
 variable "https_port" {
   description = "The port for the HTTPS load balancer"
   type        = number
   default     = 443
+  validation {
+    condition     = var.https_port >= 1 && var.https_port <= 65535
+    error_message = "You must specify exactly one port between 1 and 65535"
+  }
 }


### PR DESCRIPTION
HTTP/S load balancer supports HTTP/S on custom ports. This PR allows specifying ports - [as per documentation exactly one  port from 1-65535](https://cloud.google.com/load-balancing/docs/https?&_ga=2.263917324.-1847637666.1707923371#forwarding-rule).