### PR TITLE
feat: Changed iap enabled flag to always be passed to google_compute_backend_service as it's now required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,12 @@ resource "google_compute_backend_service" "default" {
   # To achieve a null backend security_policy, set each.value.security_policy to "" (empty string), otherwise, it fallsback to var.security_policy.
   security_policy = each.value["security_policy"] == "" ? null : (each.value["security_policy"] == null ? var.security_policy : each.value.security_policy)
 
+  iap {
+    enabled              = lookup(lookup(each.value, "iap_config", {}), "enable", false)
+    oauth2_client_id     = lookup(lookup(each.value, "iap_config", {}), "oauth2_client_id", null)
+    oauth2_client_secret = lookup(lookup(each.value, "iap_config", {}), "oauth2_client_secret", null)
+  }
+
   dynamic "backend" {
     for_each = toset(each.value["groups"])
     content {
@@ -235,14 +241,6 @@ resource "google_compute_backend_service" "default" {
     content {
       enable      = lookup(lookup(each.value, "log_config", {}), "enable", true)
       sample_rate = lookup(lookup(each.value, "log_config", {}), "sample_rate", "1.0")
-    }
-  }
-
-  dynamic "iap" {
-    for_each = lookup(lookup(each.value, "iap_config", {}), "enable", false) ? [1] : []
-    content {
-      oauth2_client_id     = lookup(lookup(each.value, "iap_config", {}), "oauth2_client_id", "")
-      oauth2_client_secret = lookup(lookup(each.value, "iap_config", {}), "oauth2_client_secret", "")
     }
   }
 

--- a/modules/dynamic_backends/versions.tf
+++ b/modules/dynamic_backends/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/serverless_negs/versions.tf
+++ b/modules/serverless_negs/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.84, < 6"
+      version = ">= 4.84, < 7"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This changes the `iap_config` to always set the iap setting to either false or true as it's now a required property of `google_compute_backend_service`