### PR TITLE
chore: update all ubuntu image families to ubuntu-2204-lts (fixes #512)

### DIFF
--- a/examples/certificate-map/mig.tf
+++ b/examples/certificate-map/mig.tf
@@ -33,7 +33,7 @@ module "mig1_template" {
   }
   name_prefix          = "${var.network_name}-group1"
   startup_script       = data.template_file.group1-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group1",

--- a/examples/https-redirect/main.tf
+++ b/examples/https-redirect/main.tf
@@ -68,7 +68,7 @@ module "mig_template" {
     scopes = ["cloud-platform"]
   }
   name_prefix          = var.network_name
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   startup_script       = data.template_file.group-startup-script.rendered
   tags = [

--- a/examples/lb-http-separate-frontend-and-backend/mig.tf
+++ b/examples/lb-http-separate-frontend-and-backend/mig.tf
@@ -41,7 +41,7 @@ module "mig1_template" {
   }
   name_prefix          = "lb-http-separate-frontend-and-backend-group1"
   startup_script       = data.template_file.group-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "lb-http-separate-frontend-and-backend-group1",

--- a/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
+++ b/examples/multi-backend-multi-mig-bucket-https-lb/mig.tf
@@ -49,7 +49,7 @@ module "mig1_template" {
   }
   name_prefix          = "${var.network_name}-group1"
   startup_script       = data.template_file.group1-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group1",
@@ -81,7 +81,7 @@ module "mig2_template" {
   }
   name_prefix          = "${var.network_name}-group2"
   startup_script       = data.template_file.group2-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group2",
@@ -114,7 +114,7 @@ module "mig3_template" {
   }
   name_prefix          = "${var.network_name}-group3"
   startup_script       = data.template_file.group3-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group3",

--- a/examples/multi-mig-http-lb/mig.tf
+++ b/examples/multi-mig-http-lb/mig.tf
@@ -41,7 +41,7 @@ module "mig1_template" {
   }
   name_prefix          = "${var.network_prefix}-group1"
   startup_script       = data.template_file.group-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_prefix}-group1",

--- a/examples/multiple-certs/mig.tf
+++ b/examples/multiple-certs/mig.tf
@@ -49,7 +49,7 @@ module "mig1_template" {
   }
   name_prefix          = "${var.network_name}-group1"
   startup_script       = data.template_file.group1-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group1",
@@ -81,7 +81,7 @@ module "mig2_template" {
   }
   name_prefix          = "${var.network_name}-group2"
   startup_script       = data.template_file.group2-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group2",
@@ -114,7 +114,7 @@ module "mig3_template" {
   }
   name_prefix          = "${var.network_name}-group3"
   startup_script       = data.template_file.group3-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group3",

--- a/examples/user-managed-google-managed-ssl/mig.tf
+++ b/examples/user-managed-google-managed-ssl/mig.tf
@@ -33,7 +33,7 @@ module "mig1_template" {
   }
   name_prefix          = "${var.network_name}-group1"
   startup_script       = data.template_file.group1-startup-script.rendered
-  source_image_family  = "ubuntu-2004-lts"
+  source_image_family  = "ubuntu-2204-lts"
   source_image_project = "ubuntu-os-cloud"
   tags = [
     "${var.network_name}-group1",


### PR DESCRIPTION
This PR updates the deprecated `ubuntu-2004-lts` image family to `ubuntu-2204-lts` across the module and example configurations.

- Updated the default value of `source_image_family` inside the `mig-template` module.
- Updated all affected example files to reference `ubuntu-2204-lts` instead of the removed `ubuntu-2004-lts` image family.

## Reason

The `ubuntu-2004-lts` family has been deprecated and is no longer available in the `ubuntu-os-cloud` GCP project, causing `terraform apply` to fail when running multiple examples from this repository.

## Testing

- Verified the change by running `terraform plan` and `terraform apply` on updated examples inside my GCP environment.
- Verified the image family `ubuntu-2204-lts` is available via:

```bash
gcloud compute images list --project=ubuntu-os-cloud --filter="family=ubuntu-2204-lts"
````

## Related Issue

Fixes #512

## Additional Information

This issue was encountered while running examples inside Qwiklabs GCP Cloud Shell.

## Note

This issue was encountered while running the [Load Balancing: HTTP(S) Load Balancer with Cloud CDN](https://www.cloudskillsboost.google/catalog_lab/1011) GSP206 lab on Google Cloud Skills Boost. Updating the image family resolves the failure and allows learners to complete the lab successfully.

