### PR TITLE
Fix: Certificate manager resource is missing https

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -120,7 +120,7 @@ resource "google_compute_target_https_proxy" "default" {
   url_map = local.url_map
 
   ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_map             = var.certificate_map != null ? "https://certificatemanager.googleapis.com/${var.certificate_map}" : null
   ssl_policy                  = var.ssl_policy
   quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
   server_tls_policy           = var.server_tls_policy

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "google_compute_target_https_proxy" "default" {
   url_map = local.url_map
 
   ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_map             = var.certificate_map != null ? "https://certificatemanager.googleapis.com/${var.certificate_map}" : null
   ssl_policy                  = var.ssl_policy
   quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
   server_tls_policy           = var.server_tls_policy

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -118,7 +118,7 @@ resource "google_compute_target_https_proxy" "default" {
   url_map = local.url_map
 
   ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_map             = var.certificate_map != null ? "https://certificatemanager.googleapis.com/${var.certificate_map}" : null
   ssl_policy                  = var.ssl_policy
   quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
   server_tls_policy           = var.server_tls_policy

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -199,7 +199,7 @@ resource "google_compute_target_https_proxy" "default" {
   url_map = local.url_map
 
   ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_map             = var.certificate_map != null ? "https://certificatemanager.googleapis.com/${var.certificate_map}" : null
   ssl_policy                  = var.ssl_policy
   quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
   server_tls_policy           = var.server_tls_policy

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -117,7 +117,7 @@ resource "google_compute_target_https_proxy" "default" {
   url_map = local.url_map
 
   ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_map             = var.certificate_map != null ? "https://certificatemanager.googleapis.com/${var.certificate_map}" : null
   ssl_policy                  = var.ssl_policy
   quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
   server_tls_policy           = var.server_tls_policy


### PR DESCRIPTION
# Description

I was having a hard time passing my own cert manager into the module. After forcing the issue with `gcloud` cli and then checking the terraform state I saw that the `https:` was missing from the cert manager resource.