### PR TITLE
feat: add network_tier parameter to forwarding rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ module "gce-lb-http" {
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | network | Network for INTERNAL\_SELF\_MANAGED load balancing scheme | `string` | `"default"` | no |
+| network\_tier | Network tier for the forwarding rule. | `string` | `null` | no |
 | private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
 | project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -53,6 +54,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default" {
@@ -77,6 +79,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
@@ -90,6 +93,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default_ipv6" {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -305,6 +305,9 @@ spec:
         description: Network for INTERNAL_SELF_MANAGED load balancing scheme
         varType: string
         defaultValue: default
+      - name: network_tier
+        description: Network tier for the forwarding rule.
+        varType: string
       - name: server_tls_policy
         description: The resource URL for the server TLS policy to associate with the https proxy service
         varType: string

--- a/modules/dynamic_backends/README.md
+++ b/modules/dynamic_backends/README.md
@@ -110,6 +110,7 @@ module "gce-lb-http" {
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | network | Network for INTERNAL\_SELF\_MANAGED load balancing scheme | `string` | `"default"` | no |
+| network\_tier | Network tier for the forwarding rule. | `string` | `null` | no |
 | private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
 | project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -40,6 +40,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -53,6 +54,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default" {
@@ -77,6 +79,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
@@ -90,6 +93,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default_ipv6" {

--- a/modules/dynamic_backends/metadata.yaml
+++ b/modules/dynamic_backends/metadata.yaml
@@ -297,6 +297,9 @@ spec:
         description: Network for INTERNAL_SELF_MANAGED load balancing scheme
         varType: string
         defaultValue: default
+      - name: network_tier
+        description: Network tier for the forwarding rule.
+        varType: string
       - name: server_tls_policy
         description: The resource URL for the server TLS policy to associate with the https proxy service
         varType: string

--- a/modules/dynamic_backends/variables.tf
+++ b/modules/dynamic_backends/variables.tf
@@ -299,6 +299,16 @@ variable "network" {
   default     = "default"
 }
 
+variable "network_tier" {
+  description = "Network tier for the forwarding rule."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.network_tier == null || contains(["PREMIUM", "STANDARD"], var.network_tier)
+    error_message = "Network tier must be PREMIUM or STANDARD."
+  }
+}
+
 variable "server_tls_policy" {
   description = "The resource URL for the server TLS policy to associate with the https proxy service"
   type        = string

--- a/modules/frontend/README.md
+++ b/modules/frontend/README.md
@@ -26,6 +26,7 @@ This module creates `HTTP(S) forwarding rule` and its dependencies. This modules
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | network | VPC network for the forwarding rule. The VPC network should have exactly one GLOBAL\_MANAGED\_PROXY subnetwork for every region where the forwarding rule is to be configured. Please go to the subnets tab of your VPC network and check if a GLOBAL\_MANAGED\_PROXY subnet exists under the `Reserved proxy-only subnets for load balancing` section. If a GLOBAL\_MANAGED\_PROXY subnet doesn't exist, create one for each required region. | `string` | `"default"` | no |
+| network\_tier | Network tier for the forwarding rule. | `string` | `null` | no |
 | private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
 | project\_id | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -55,6 +55,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_http" {
@@ -72,6 +73,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_http" {
   network               = local.internal_network
   subnetwork            = each.value.subnetwork
   ip_address            = each.value.address
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -85,6 +87,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_https" {
@@ -102,6 +105,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_https" {
   network               = local.internal_network
   subnetwork            = each.value.subnetwork
   ip_address            = each.value.address
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default" {
@@ -126,6 +130,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_http_ipv6" {
@@ -142,6 +147,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_http_ipv6" {
   load_balancing_scheme = var.load_balancing_scheme
   subnetwork            = each.value.subnetwork
   ip_address            = each.value.address
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
@@ -155,6 +161,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_https_ipv6" {
@@ -171,6 +178,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_https_ipv6" {
   load_balancing_scheme = var.load_balancing_scheme
   subnetwork            = each.value.subnetwork
   ip_address            = each.value.address
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default_ipv6" {

--- a/modules/frontend/metadata.yaml
+++ b/modules/frontend/metadata.yaml
@@ -187,6 +187,9 @@ spec:
         description: VPC network for the forwarding rule. The VPC network should have exactly one GLOBAL_MANAGED_PROXY subnetwork for every region where the forwarding rule is to be configured. Please go to the subnets tab of your VPC network and check if a GLOBAL_MANAGED_PROXY subnet exists under the `Reserved proxy-only subnets for load balancing` section. If a GLOBAL_MANAGED_PROXY subnet doesn't exist, create one for each required region.
         varType: string
         defaultValue: default
+      - name: network_tier
+        description: Network tier for the forwarding rule.
+        varType: string
       - name: server_tls_policy
         description: The resource URL for the server TLS policy to associate with the https proxy service
         varType: string

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -167,6 +167,16 @@ variable "network" {
   default     = "default"
 }
 
+variable "network_tier" {
+  description = "Network tier for the forwarding rule."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.network_tier == null || contains(["PREMIUM", "STANDARD"], var.network_tier)
+    error_message = "Network tier must be PREMIUM or STANDARD."
+  }
+}
+
 variable "server_tls_policy" {
   description = "The resource URL for the server TLS policy to associate with the https proxy service"
   type        = string

--- a/modules/serverless_negs/README.md
+++ b/modules/serverless_negs/README.md
@@ -93,6 +93,7 @@ module "lb-http" {
 | managed\_ssl\_certificate\_domains | Create Google-managed SSL certificates for specified domains. Requires `ssl` to be set to `true` | `list(string)` | `[]` | no |
 | name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
 | network | Network for INTERNAL\_SELF\_MANAGED load balancing scheme | `string` | `"default"` | no |
+| network\_tier | Network tier for the forwarding rule. | `string` | `null` | no |
 | private\_key | Content of the private SSL key. Requires `ssl` to be set to `true` and `create_ssl_certificate` set to `true` | `string` | `null` | no |
 | project | The project to deploy to, if not set the default provider project is used. | `string` | n/a | yes |
 | quic | Specifies the QUIC override policy for this resource. Set true to enable HTTP/3 and Google QUIC support, false to disable both. Defaults to null which enables support for HTTP/3 only. | `bool` | `null` | no |

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -39,6 +39,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -52,6 +53,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default" {
@@ -76,6 +78,7 @@ resource "google_compute_global_forwarding_rule" "http_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_forwarding_rule" "https_ipv6" {
@@ -89,6 +92,7 @@ resource "google_compute_global_forwarding_rule" "https_ipv6" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  network_tier          = var.network_tier
 }
 
 resource "google_compute_global_address" "default_ipv6" {

--- a/modules/serverless_negs/metadata.yaml
+++ b/modules/serverless_negs/metadata.yaml
@@ -261,6 +261,9 @@ spec:
         description: Network for INTERNAL_SELF_MANAGED load balancing scheme
         varType: string
         defaultValue: default
+      - name: network_tier
+        description: Network tier for the forwarding rule.
+        varType: string
       - name: server_tls_policy
         description: The resource URL for the server TLS policy to associate with the https proxy service
         varType: string

--- a/modules/serverless_negs/variables.tf
+++ b/modules/serverless_negs/variables.tf
@@ -268,6 +268,16 @@ variable "network" {
   default     = "default"
 }
 
+variable "network_tier" {
+  description = "Network tier for the forwarding rule."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.network_tier == null || contains(["PREMIUM", "STANDARD"], var.network_tier)
+    error_message = "Network tier must be PREMIUM or STANDARD."
+  }
+}
+
 variable "server_tls_policy" {
   description = "The resource URL for the server TLS policy to associate with the https proxy service"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -299,6 +299,16 @@ variable "network" {
   default     = "default"
 }
 
+variable "network_tier" {
+  description = "Network tier for the forwarding rule."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.network_tier == null || contains(["PREMIUM", "STANDARD"], var.network_tier)
+    error_message = "Network tier must be PREMIUM or STANDARD."
+  }
+}
+
 variable "server_tls_policy" {
   description = "The resource URL for the server TLS policy to associate with the https proxy service"
   type        = string


### PR DESCRIPTION
Allows users to explicitly set the Network Service Tier (PREMIUM or STANDARD). This prevents deployment failures in projects where the default network tier is set to STANDARD, ensuring compatibility with global forwarding rules.

Updated:
- Root module
- Serverless NEGs submodule
- Dynamic backends submodule
- Frontend configuration