### PR TITLE
fix: use dynamic iap block to prevent perpetual no-op diff

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -256,10 +256,13 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  iap {
-    enabled              = try(each.value["iap_config"], null) == null ? false : lookup(try(each.value["iap_config"], {}), "enable", false)
-    oauth2_client_id     = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_id")
-    oauth2_client_secret = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_secret")
+  dynamic "iap" {
+    for_each = try(each.value["iap_config"], null) != null ? [each.value["iap_config"]] : []
+    content {
+      enabled              = lookup(iap.value, "enable", false)
+      oauth2_client_id     = lookup(iap.value, "oauth2_client_id", null)
+      oauth2_client_secret = lookup(iap.value, "oauth2_client_secret", null)
+    }
   }
 
   dynamic "cdn_policy" {

--- a/main.tf
+++ b/main.tf
@@ -238,10 +238,13 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  iap {
-    enabled              = try(each.value["iap_config"], null) == null ? false : lookup(try(each.value["iap_config"], {}), "enable", false)
-    oauth2_client_id     = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_id")
-    oauth2_client_secret = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_secret")
+  dynamic "iap" {
+    for_each = try(each.value["iap_config"], null) != null ? [each.value["iap_config"]] : []
+    content {
+      enabled              = lookup(iap.value, "enable", false)
+      oauth2_client_id     = lookup(iap.value, "oauth2_client_id", null)
+      oauth2_client_secret = lookup(iap.value, "oauth2_client_secret", null)
+    }
   }
 
   dynamic "cdn_policy" {

--- a/modules/dynamic_backends/main.tf
+++ b/modules/dynamic_backends/main.tf
@@ -238,10 +238,13 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  iap {
-    enabled              = try(each.value["iap_config"], null) == null ? false : lookup(try(each.value["iap_config"], {}), "enable", false)
-    oauth2_client_id     = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_id")
-    oauth2_client_secret = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_secret")
+  dynamic "iap" {
+    for_each = try(each.value["iap_config"], null) != null ? [each.value["iap_config"]] : []
+    content {
+      enabled              = lookup(iap.value, "enable", false)
+      oauth2_client_id     = lookup(iap.value, "oauth2_client_id", null)
+      oauth2_client_secret = lookup(iap.value, "oauth2_client_secret", null)
+    }
   }
 
   dynamic "cdn_policy" {

--- a/modules/serverless_negs/main.tf
+++ b/modules/serverless_negs/main.tf
@@ -233,10 +233,13 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  iap {
-    enabled              = try(each.value["iap_config"], null) == null ? false : lookup(try(each.value["iap_config"], {}), "enable", false)
-    oauth2_client_id     = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_id")
-    oauth2_client_secret = try(each.value["iap_config"], null) == null ? null : lookup(each.value["iap_config"], "oauth2_client_secret")
+  dynamic "iap" {
+    for_each = try(each.value["iap_config"], null) != null ? [each.value["iap_config"]] : []
+    content {
+      enabled              = lookup(iap.value, "enable", false)
+      oauth2_client_id     = lookup(iap.value, "oauth2_client_id", null)
+      oauth2_client_secret = lookup(iap.value, "oauth2_client_secret", null)
+    }
   }
 
   dynamic "cdn_policy" {


### PR DESCRIPTION
## Problem

When `iap_config` is not provided in a backend configuration, the static `iap` block sets `oauth2_client_id` to `null`. However, the GCP API returns `" "` (a single space) for unset `oauth2_client_id` values, causing Terraform to detect a diff on every plan:

```
~ iap {
    - oauth2_client_id = " " -> null
  }
```

This results in a perpetual no-op update to `google_compute_backend_service` resources that don't use IAP.

## Solution

Make the `iap` block dynamic so it is only rendered when `iap_config` is explicitly provided. When `iap_config` is absent, the block is omitted entirely, and Terraform no longer tries to reconcile `null` vs the `" "` returned by the API.

## Changes

The same change is applied in all 4 locations where the `iap` block appears:

- `main.tf`
- `modules/serverless_negs/main.tf`
- `modules/dynamic_backends/main.tf`
- `autogen/main.tf.tmpl`

**Before:**
```hcl
iap {
  enabled              = try(each.value["iap_config"], null) == null ? false : ...
  oauth2_client_id     = try(each.value["iap_config"], null) == null ? null : ...
  oauth2_client_secret = try(each.value["iap_config"], null) == null ? null : ...
}
```

**After:**
```hcl
dynamic "iap" {
  for_each = try(each.value["iap_config"], null) != null ? [each.value["iap_config"]] : []
  content {
    enabled              = lookup(iap.value, "enable", false)
    oauth2_client_id     = lookup(iap.value, "oauth2_client_id", null)
    oauth2_client_secret = lookup(iap.value, "oauth2_client_secret", null)
  }
}
```

## Backward Compatibility

This is a non-breaking change:
- Backends with `iap_config` set behave identically to before
- Backends without `iap_config` simply stop producing the phantom diff

Related: #451, hashicorp/terraform-provider-google#16585