### PR TITLE
feat: add support for internal_managed load balancer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ locals {
 
   health_checked_backends = { for backend_index, backend_value in var.backends : backend_index => backend_value if backend_value["health_check"] != null }
 
-  is_internal      = var.load_balancing_scheme == "INTERNAL_SELF_MANAGED"
+  is_internal      = var.load_balancing_scheme == "INTERNAL_SELF_MANAGED" || var.load_balancing_scheme == "INTERNAL_MANAGED"
   internal_network = local.is_internal ? var.network : null
 }
 


### PR DESCRIPTION
This PR aim to add INTERNAL_MANAGED load balancer support.

I managed to use this config to create a internal load balancer with multiple Cloud Run serverless NEGs and host, path routing without using the frontend and backend modules.

PS: I tried to run `make build` but it didn't work.