### PR TITLE
feat: add certificate_manager_certificates support to HTTPS proxy

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,7 +119,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,12 +119,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -281,6 +281,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/main.tf
+++ b/main.tf
@@ -117,12 +117,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -198,7 +198,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -198,12 +198,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -125,6 +125,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"

--- a/variables.tf
+++ b/variables.tf
@@ -245,6 +245,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"


### PR DESCRIPTION
Add `certificate_manager_certificates` variable to the root module and `modules/frontend`, enabling direct attachment of Certificate Manager certificates to the global HTTPS proxy. This fills the gap between `certificate_map` (indirect, requires map + entry resources) and the direct-attach API field supported by `google_compute_target_https_proxy`.

This is particularly needed for INTERNAL_MANAGED load balancers where Certificate Manager certs must be attached directly to the global proxy.

Backward compatible: new variable defaults to `[]` and resolves to `null` on the resource when not provided, leaving all existing configurations unchanged.