### PR TITLE
feat: certificate_manager_certificates, url_map_config extensions, resource name overrides, backend improvements

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,7 +119,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -119,12 +119,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -116,7 +116,7 @@ resource "google_compute_target_http_proxy" "default" {
 resource "google_compute_target_https_proxy" "default" {
   project = var.project
   count   = var.ssl ? 1 : 0
-  name    = "${var.name}-https-proxy"
+  name    = coalesce(var.target_https_proxy_name, "${var.name}-https-proxy")
   url_map = local.url_map
 
   ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -372,3 +372,9 @@ variable "http_keep_alive_timeout_sec" {
   type        = number
   default     = null
 }
+
+variable "target_https_proxy_name" {
+  description = "Override the target HTTPS proxy resource name. Defaults to `<name>-https-proxy` when null."
+  type        = string
+  default     = null
+}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -281,6 +281,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/main.tf
+++ b/main.tf
@@ -117,12 +117,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "google_compute_target_http_proxy" "default" {
 resource "google_compute_target_https_proxy" "default" {
   project = var.project
   count   = var.ssl ? 1 : 0
-  name    = "${var.name}-https-proxy"
+  name    = coalesce(var.target_https_proxy_name, "${var.name}-https-proxy")
   url_map = local.url_map
 
   ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -37,6 +37,7 @@ resource "google_compute_backend_service" "default" {
   connection_draining_timeout_sec = var.connection_draining_timeout_sec
   enable_cdn                      = var.enable_cdn
   compression_mode                = var.load_balancing_scheme == "INTERNAL_SELF_MANAGED" || var.load_balancing_scheme == "INTERNAL_MANAGED" ? null : var.compression_mode
+  ip_address_selection_policy     = var.ip_address_selection_policy
   custom_request_headers          = var.custom_request_headers
   custom_response_headers         = var.custom_response_headers
   session_affinity                = var.session_affinity
@@ -46,7 +47,7 @@ resource "google_compute_backend_service" "default" {
   security_policy                 = var.security_policy
   timeout_sec                     = var.timeout_sec
 
-  health_checks = var.health_check != null ? google_compute_health_check.default[*].self_link : null
+  health_checks = length(var.health_check_self_links) > 0 ? var.health_check_self_links : (var.health_check != null ? google_compute_health_check.default[*].self_link : null)
 
   dynamic "backend" {
     for_each = toset(var.groups)
@@ -63,6 +64,7 @@ resource "google_compute_backend_service" "default" {
       max_rate_per_instance        = backend.value["max_rate_per_instance"]
       max_rate_per_endpoint        = backend.value["max_rate_per_endpoint"]
       max_utilization              = backend.value["max_utilization"]
+      preference                   = lookup(backend.value, "preference", null)
     }
   }
 
@@ -83,8 +85,9 @@ resource "google_compute_backend_service" "default" {
   dynamic "log_config" {
     for_each = var.log_config.enable ? [1] : []
     content {
-      enable      = var.log_config.enable
-      sample_rate = var.log_config.sample_rate
+      enable        = var.log_config.enable
+      sample_rate   = var.log_config.sample_rate
+      optional_mode = var.log_config.optional_mode
     }
   }
 
@@ -233,7 +236,7 @@ resource "google_compute_region_network_endpoint_group" "psc_negs" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  count    = var.health_check != null ? 1 : 0
+  count    = var.health_check != null && length(var.health_check_self_links) == 0 ? 1 : 0
   project  = var.project_id
   name     = coalesce(var.health_check_name, "${var.name}-hc")
 

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -82,13 +82,10 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  dynamic "log_config" {
-    for_each = var.log_config.enable ? [1] : []
-    content {
-      enable        = var.log_config.enable
-      sample_rate   = var.log_config.sample_rate
-      optional_mode = var.log_config.optional_mode
-    }
+  log_config {
+    enable        = var.log_config.enable
+    sample_rate   = var.log_config.sample_rate
+    optional_mode = var.log_config.optional_mode
   }
 
   dynamic "iap" {

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -82,10 +82,13 @@ resource "google_compute_backend_service" "default" {
     }
   }
 
-  log_config {
-    enable        = var.log_config.enable
-    sample_rate   = var.log_config.sample_rate
-    optional_mode = var.log_config.optional_mode
+  dynamic "log_config" {
+    for_each = var.log_config.enable || var.log_config.optional_mode != null ? [1] : []
+    content {
+      enable        = var.log_config.enable
+      sample_rate   = var.log_config.sample_rate
+      optional_mode = var.log_config.optional_mode
+    }
   }
 
   dynamic "iap" {

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -235,7 +235,7 @@ resource "google_compute_health_check" "default" {
   provider = google-beta
   count    = var.health_check != null ? 1 : 0
   project  = var.project_id
-  name     = "${var.name}-hc"
+  name     = coalesce(var.health_check_name, "${var.name}-hc")
 
   check_interval_sec  = var.health_check.check_interval_sec
   timeout_sec         = var.health_check.timeout_sec

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -371,6 +371,7 @@ resource "google_compute_backend_bucket" "default" {
       max_ttl                      = var.cdn_policy.max_ttl
       client_ttl                   = var.cdn_policy.client_ttl
       negative_caching             = var.cdn_policy.negative_caching
+      request_coalescing           = var.cdn_policy.request_coalescing
       serve_while_stale            = var.cdn_policy.serve_while_stale
 
       dynamic "negative_caching_policy" {

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -109,6 +109,7 @@ resource "google_compute_backend_service" "default" {
       max_ttl                      = var.cdn_policy.max_ttl
       client_ttl                   = var.cdn_policy.client_ttl
       negative_caching             = var.cdn_policy.negative_caching
+      request_coalescing           = var.cdn_policy.request_coalescing
       serve_while_stale            = var.cdn_policy.serve_while_stale
 
       dynamic "negative_caching_policy" {

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -353,10 +353,11 @@ resource "google_compute_backend_bucket" "default" {
   provider = google-beta
   count    = local.is_backend_bucket ? 1 : 0
 
-  project     = var.project_id
-  name        = var.name
-  bucket_name = var.backend_bucket_name
-  enable_cdn  = var.enable_cdn
+  project          = var.project_id
+  name             = var.name
+  bucket_name      = var.backend_bucket_name
+  enable_cdn       = var.enable_cdn
+  compression_mode = var.compression_mode
 
   description = var.description
 

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -363,7 +363,8 @@ resource "google_compute_backend_bucket" "default" {
   enable_cdn       = var.enable_cdn
   compression_mode = var.compression_mode
 
-  description = var.description
+  description             = var.description
+  custom_response_headers = var.custom_response_headers
 
   # CDN policy configuration, if CDN is enabled
   dynamic "cdn_policy" {

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -186,6 +186,7 @@ variable "cdn_policy" {
     max_ttl                         = optional(number)
     client_ttl                      = optional(number)
     negative_caching                = optional(bool)
+    request_coalescing              = optional(bool)
     serve_while_stale               = optional(number)
     bypass_cache_on_request_headers = optional(list(string))
     negative_caching_policy = optional(object({

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -113,7 +113,7 @@ variable "log_config" {
   description = "This field denotes the logging options for the load balancer traffic served by this backend service. If logging is enabled, logs will be exported to Stackdriver."
   type = object({
     enable        = bool
-    sample_rate   = number
+    sample_rate   = optional(number)
     optional_mode = optional(string)
   })
   default = { enable = true, sample_rate = 1.0 }

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -103,11 +103,18 @@ variable "timeout_sec" {
   default     = null
 }
 
+variable "ip_address_selection_policy" {
+  description = "Specifies preference of traffic to the backend (among backends that each have adequate capacity). Accepted values: IPV4_ONLY, IPV6_ONLY, PREFER_IPV6."
+  type        = string
+  default     = null
+}
+
 variable "log_config" {
   description = "This field denotes the logging options for the load balancer traffic served by this backend service. If logging is enabled, logs will be exported to Stackdriver."
   type = object({
-    enable      = bool
-    sample_rate = number
+    enable        = bool
+    sample_rate   = number
+    optional_mode = optional(string)
   })
   default = { enable = true, sample_rate = 1.0 }
 }
@@ -127,6 +134,7 @@ variable "groups" {
     max_rate_per_instance        = optional(number)
     max_rate_per_endpoint        = optional(number)
     max_utilization              = optional(number)
+    preference                   = optional(string)
   }))
   default = []
 }
@@ -255,6 +263,12 @@ variable "health_check" {
     logging             = optional(bool, false)
   })
   default = null
+}
+
+variable "health_check_self_links" {
+  description = "Self links of pre-existing health checks to attach to the backend service directly. Mutually exclusive with health_check — when non-empty, no health check resource is created."
+  type        = list(string)
+  default     = []
 }
 
 variable "edge_security_policy" {

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -307,6 +307,12 @@ variable "firewall_source_ranges" {
   default     = ["10.127.0.0/23"]
 }
 
+variable "health_check_name" {
+  description = "Override the health check resource name. Defaults to `<name>-hc` when null."
+  type        = string
+  default     = null
+}
+
 check "backend_neg_type_exclusive" {
   assert {
     condition     = length(var.serverless_neg_backends) == 0 || length(var.psc_neg_backends) == 0

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -94,7 +94,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_https" {
 
   provider              = google-beta
   project               = var.project_id
-  name                  = "${var.name}-internal-managed-https-${each.key}"
+  name                  = lookup(var.forwarding_rule_names, each.key, "${var.name}-internal-managed-https-${each.key}")
   target                = google_compute_target_https_proxy.default[0].self_link
   port_range            = var.https_port
   labels                = var.labels
@@ -195,7 +195,7 @@ resource "google_compute_target_http_proxy" "default" {
 resource "google_compute_target_https_proxy" "default" {
   project = var.project_id
   count   = var.ssl ? 1 : 0
-  name    = "${var.name}-https-proxy"
+  name    = coalesce(var.target_https_proxy_name, "${var.name}-https-proxy")
   url_map = local.url_map
 
   ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -64,7 +64,7 @@ resource "google_compute_global_forwarding_rule" "internal_managed_http" {
 
   provider              = google-beta
   project               = var.project_id
-  name                  = "${var.name}-internal-managed-http-${each.key}"
+  name                  = lookup(var.http_forwarding_rule_names, each.key, "${var.name}-internal-managed-http-${each.key}")
   target                = google_compute_target_http_proxy.default[0].self_link
   port_range            = var.http_port
   labels                = var.labels

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   provider              = google-beta
   project               = var.project_id
   count                 = local.create_http_forward && !local.is_internal_managed ? 1 : 0
-  name                  = var.name
+  name                  = coalesce(var.http_forwarding_rule_name, var.name)
   target                = google_compute_target_http_proxy.default[0].self_link
   ip_address            = local.address
   port_range            = var.http_port
@@ -78,7 +78,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   provider              = google-beta
   project               = var.project_id
   count                 = var.ssl && !local.is_internal_managed ? 1 : 0
-  name                  = "${var.name}-https"
+  name                  = coalesce(var.https_forwarding_rule_name, "${var.name}-https")
   target                = google_compute_target_https_proxy.default[0].self_link
   ip_address            = local.address
   port_range            = var.https_port

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -198,7 +198,7 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  ssl_certificates                 = length(var.certificate_manager_certificates) > 0 ? null : compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
   certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
   certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
   ssl_policy                       = var.ssl_policy

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -254,6 +254,17 @@ resource "google_compute_url_map" "custom" {
 
   default_service = var.url_map_config != null ? var.url_map_config.default_service : null
 
+  dynamic "default_url_redirect" {
+    for_each = try(var.url_map_config.default_url_redirect, null) != null ? [var.url_map_config.default_url_redirect] : []
+    content {
+      host_redirect          = default_url_redirect.value.host_redirect
+      path_redirect          = default_url_redirect.value.path_redirect
+      https_redirect         = default_url_redirect.value.https_redirect
+      redirect_response_code = default_url_redirect.value.redirect_response_code
+      strip_query            = default_url_redirect.value.strip_query
+    }
+  }
+
   dynamic "host_rule" {
     for_each = var.url_map_config != null ? var.url_map_config.host_rules : []
     content {

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -187,7 +187,7 @@ resource "google_compute_global_address" "default_ipv6" {
 resource "google_compute_target_http_proxy" "default" {
   project = var.project_id
   count   = local.create_http_forward ? 1 : 0
-  name    = "${var.name}-http-proxy"
+  name    = coalesce(var.target_http_proxy_name, "${var.name}-http-proxy")
   url_map = var.https_redirect == false ? local.url_map : join("", google_compute_url_map.https_redirect[*].self_link)
 }
 

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -55,6 +55,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  ip_version            = var.ip_version
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_http" {
@@ -85,6 +86,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   labels                = var.labels
   load_balancing_scheme = var.load_balancing_scheme
   network               = local.internal_network
+  ip_version            = var.ip_version
 }
 
 resource "google_compute_global_forwarding_rule" "internal_managed_https" {

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -19,7 +19,7 @@ locals {
   address      = var.create_address ? join("", google_compute_global_address.default[*].address) : var.address
   ipv6_address = var.create_ipv6_address ? join("", google_compute_global_address.default_ipv6[*].address) : var.ipv6_address
 
-  url_map             = var.create_url_map ? join("", google_compute_url_map.default[*].self_link) : var.url_map_resource_uri
+  url_map             = var.create_url_map ? (var.url_map_config != null ? join("", google_compute_url_map.custom[*].self_link) : join("", google_compute_url_map.default[*].self_link)) : var.url_map_resource_uri
   create_http_forward = var.http_forward || var.https_redirect
 
 
@@ -246,6 +246,58 @@ resource "google_compute_managed_ssl_certificate" "default" {
   }
 }
 
+resource "google_compute_url_map" "custom" {
+  count    = var.create_url_map && var.url_map_config != null ? 1 : 0
+  provider = google-beta
+  project  = var.project_id
+  name     = coalesce(var.url_map_name, "${var.name}-url-map")
+
+  default_service = var.url_map_config != null ? var.url_map_config.default_service : null
+
+  dynamic "host_rule" {
+    for_each = var.url_map_config != null ? var.url_map_config.host_rules : []
+    content {
+      hosts        = host_rule.value.hosts
+      path_matcher = host_rule.value.path_matcher
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = var.url_map_config != null ? var.url_map_config.path_matchers : []
+    content {
+      name            = path_matcher.value.name
+      default_service = path_matcher.value.default_service
+
+      dynamic "route_rules" {
+        for_each = path_matcher.value.route_rules
+        content {
+          priority = route_rules.value.priority
+
+          dynamic "match_rules" {
+            for_each = route_rules.value.match_rules
+            content {
+              prefix_match    = match_rules.value.prefix_match
+              full_path_match = match_rules.value.full_path_match
+              regex_match     = match_rules.value.regex_match
+            }
+          }
+
+          dynamic "url_redirect" {
+            for_each = route_rules.value.url_redirect != null ? [1] : []
+            content {
+              host_redirect          = route_rules.value.url_redirect.host_redirect
+              path_redirect          = route_rules.value.url_redirect.path_redirect
+              https_redirect         = route_rules.value.url_redirect.https_redirect
+              redirect_response_code = route_rules.value.url_redirect.redirect_response_code
+              strip_query            = route_rules.value.url_redirect.strip_query
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 resource "google_compute_url_map" "https_redirect" {
   project = var.project_id
   count   = var.https_redirect ? 1 : 0
@@ -258,10 +310,10 @@ resource "google_compute_url_map" "https_redirect" {
 }
 
 resource "google_compute_url_map" "default" {
-  count           = var.create_url_map && length(local.backend_services_by_host) > 0 ? 1 : 0
+  count           = var.create_url_map && var.url_map_config == null && length(local.backend_services_by_host) > 0 ? 1 : 0
   provider        = google-beta
   project         = var.project_id
-  name            = "${var.name}-url-map"
+  name            = coalesce(var.url_map_name, "${var.name}-url-map")
   default_service = lookup(lookup(local.backend_services_by_host, "*", {}), "/*", local.first_backend_service)
 
   dynamic "host_rule" {

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -268,6 +268,35 @@ resource "google_compute_url_map" "custom" {
       name            = path_matcher.value.name
       default_service = path_matcher.value.default_service
 
+      dynamic "default_url_redirect" {
+        for_each = path_matcher.value.default_url_redirect != null ? [1] : []
+        content {
+          host_redirect          = path_matcher.value.default_url_redirect.host_redirect
+          path_redirect          = path_matcher.value.default_url_redirect.path_redirect
+          https_redirect         = path_matcher.value.default_url_redirect.https_redirect
+          redirect_response_code = path_matcher.value.default_url_redirect.redirect_response_code
+          strip_query            = path_matcher.value.default_url_redirect.strip_query
+        }
+      }
+
+      dynamic "path_rule" {
+        for_each = path_matcher.value.path_rules
+        content {
+          paths   = path_rule.value.paths
+          service = path_rule.value.service
+          dynamic "url_redirect" {
+            for_each = path_rule.value.url_redirect != null ? [1] : []
+            content {
+              host_redirect          = path_rule.value.url_redirect.host_redirect
+              path_redirect          = path_rule.value.url_redirect.path_redirect
+              https_redirect         = path_rule.value.url_redirect.https_redirect
+              redirect_response_code = path_rule.value.url_redirect.redirect_response_code
+              strip_query            = path_rule.value.url_redirect.strip_query
+            }
+          }
+        }
+      }
+
       dynamic "route_rules" {
         for_each = path_matcher.value.route_rules
         content {
@@ -279,6 +308,13 @@ resource "google_compute_url_map" "custom" {
               prefix_match    = match_rules.value.prefix_match
               full_path_match = match_rules.value.full_path_match
               regex_match     = match_rules.value.regex_match
+              dynamic "header_matches" {
+                for_each = match_rules.value.header_matches
+                content {
+                  header_name = header_matches.value.header_name
+                  exact_match = header_matches.value.exact_match
+                }
+              }
             }
           }
 
@@ -290,6 +326,19 @@ resource "google_compute_url_map" "custom" {
               https_redirect         = route_rules.value.url_redirect.https_redirect
               redirect_response_code = route_rules.value.url_redirect.redirect_response_code
               strip_query            = route_rules.value.url_redirect.strip_query
+            }
+          }
+
+          dynamic "route_action" {
+            for_each = route_rules.value.route_action != null ? [1] : []
+            content {
+              dynamic "weighted_backend_services" {
+                for_each = route_rules.value.route_action.weighted_backend_services
+                content {
+                  backend_service = weighted_backend_services.value.backend_service
+                  weight          = weighted_backend_services.value.weight
+                }
+              }
             }
           }
         }

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -198,12 +198,13 @@ resource "google_compute_target_https_proxy" "default" {
   name    = "${var.name}-https-proxy"
   url_map = local.url_map
 
-  ssl_certificates            = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
-  certificate_map             = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
-  ssl_policy                  = var.ssl_policy
-  quic_override               = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
-  server_tls_policy           = var.server_tls_policy
-  http_keep_alive_timeout_sec = var.http_keep_alive_timeout_sec
+  ssl_certificates                 = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default[*].self_link, google_compute_managed_ssl_certificate.default[*].self_link, ), )
+  certificate_map                  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+  certificate_manager_certificates = length(var.certificate_manager_certificates) > 0 ? var.certificate_manager_certificates : null
+  ssl_policy                       = var.ssl_policy
+  quic_override                    = var.quic == null ? "NONE" : var.quic ? "ENABLE" : "DISABLE"
+  server_tls_policy                = var.server_tls_policy
+  http_keep_alive_timeout_sec      = var.http_keep_alive_timeout_sec
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -250,3 +250,9 @@ variable "http_forwarding_rule_names" {
   type        = map(string)
   default     = {}
 }
+
+variable "ip_version" {
+  description = "IP version for EXTERNAL forwarding rules. Set to `IPV4` when importing a resource that was originally created with ip_version explicitly set (prevents forced replacement). Defaults to null (GCP default: IPV4)."
+  type        = string
+  default     = null
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -226,3 +226,9 @@ variable "forwarding_rule_names" {
   type        = map(string)
   default     = {}
 }
+
+variable "http_forwarding_rule_names" {
+  description = "Map of region to HTTP forwarding rule name override for INTERNAL_MANAGED. Defaults to `<name>-internal-managed-http-<region>` for any region not present in the map."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -274,12 +274,34 @@ variable "url_map_config" {
     path_matchers = optional(list(object({
       name            = string
       default_service = optional(string)
+      default_url_redirect = optional(object({
+        host_redirect          = optional(string)
+        path_redirect          = optional(string)
+        https_redirect         = optional(bool)
+        redirect_response_code = optional(string)
+        strip_query            = optional(bool)
+      }))
+      path_rules = optional(list(object({
+        paths   = list(string)
+        service = optional(string)
+        url_redirect = optional(object({
+          host_redirect          = optional(string)
+          path_redirect          = optional(string)
+          https_redirect         = optional(bool)
+          redirect_response_code = optional(string)
+          strip_query            = optional(bool)
+        }))
+      })), [])
       route_rules = optional(list(object({
         priority = number
         match_rules = optional(list(object({
           prefix_match    = optional(string)
           full_path_match = optional(string)
           regex_match     = optional(string)
+          header_matches = optional(list(object({
+            header_name = string
+            exact_match = optional(string)
+          })), [])
         })), [])
         url_redirect = optional(object({
           host_redirect          = optional(string)
@@ -287,6 +309,12 @@ variable "url_map_config" {
           https_redirect         = optional(bool)
           redirect_response_code = optional(string)
           strip_query            = optional(bool)
+        }))
+        route_action = optional(object({
+          weighted_backend_services = optional(list(object({
+            backend_service = string
+            weight          = number
+          })), [])
         }))
       })), [])
     })), [])

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -215,6 +215,18 @@ variable "internal_forwarding_rules_config" {
   default = []
 }
 
+variable "http_forwarding_rule_name" {
+  description = "Override the HTTP forwarding rule name for EXTERNAL load balancers. Defaults to `<name>` when null."
+  type        = string
+  default     = null
+}
+
+variable "https_forwarding_rule_name" {
+  description = "Override the HTTPS forwarding rule name for EXTERNAL load balancers. Defaults to `<name>-https` when null."
+  type        = string
+  default     = null
+}
+
 variable "target_http_proxy_name" {
   description = "Override the target HTTP proxy resource name. Defaults to `<name>-http-proxy` when null."
   type        = string

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -267,6 +267,13 @@ variable "url_map_config" {
   description = "Direct URL map configuration with full host_rule/path_matcher/route_rules support. Supports cross-project default_service self-links. Mutually exclusive with url_map_input — when set, url_map_input is ignored. Backward compatible: default null preserves existing url_map_input behaviour."
   type = object({
     default_service = optional(string)
+    default_url_redirect = optional(object({
+      host_redirect          = optional(string)
+      path_redirect          = optional(string)
+      https_redirect         = optional(bool)
+      redirect_response_code = optional(string)
+      strip_query            = optional(bool)
+    }))
     host_rules = optional(list(object({
       hosts        = list(string)
       path_matcher = string

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -215,6 +215,12 @@ variable "internal_forwarding_rules_config" {
   default = []
 }
 
+variable "target_http_proxy_name" {
+  description = "Override the target HTTP proxy resource name. Defaults to `<name>-http-proxy` when null."
+  type        = string
+  default     = null
+}
+
 variable "target_https_proxy_name" {
   description = "Override the target HTTPS proxy resource name. Defaults to `<name>-https-proxy` when null."
   type        = string

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -214,3 +214,15 @@ variable "internal_forwarding_rules_config" {
   }))
   default = []
 }
+
+variable "target_https_proxy_name" {
+  description = "Override the target HTTPS proxy resource name. Defaults to `<name>-https-proxy` when null."
+  type        = string
+  default     = null
+}
+
+variable "forwarding_rule_names" {
+  description = "Map of region to forwarding rule name override for INTERNAL_MANAGED. Defaults to `<name>-internal-managed-https-<region>` for any region not present in the map."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -125,6 +125,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -256,3 +256,40 @@ variable "ip_version" {
   type        = string
   default     = null
 }
+
+variable "url_map_name" {
+  description = "Override the URL map resource name. Defaults to `<name>-url-map` when null."
+  type        = string
+  default     = null
+}
+
+variable "url_map_config" {
+  description = "Direct URL map configuration with full host_rule/path_matcher/route_rules support. Supports cross-project default_service self-links. Mutually exclusive with url_map_input — when set, url_map_input is ignored. Backward compatible: default null preserves existing url_map_input behaviour."
+  type = object({
+    default_service = optional(string)
+    host_rules = optional(list(object({
+      hosts        = list(string)
+      path_matcher = string
+    })), [])
+    path_matchers = optional(list(object({
+      name            = string
+      default_service = optional(string)
+      route_rules = optional(list(object({
+        priority = number
+        match_rules = optional(list(object({
+          prefix_match    = optional(string)
+          full_path_match = optional(string)
+          regex_match     = optional(string)
+        })), [])
+        url_redirect = optional(object({
+          host_redirect          = optional(string)
+          path_redirect          = optional(string)
+          https_redirect         = optional(bool)
+          redirect_response_code = optional(string)
+          strip_query            = optional(bool)
+        }))
+      })), [])
+    })), [])
+  })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -336,3 +336,9 @@ variable "http_keep_alive_timeout_sec" {
   type        = number
   default     = null
 }
+
+variable "target_https_proxy_name" {
+  description = "Override the target HTTPS proxy resource name. Defaults to `<name>-https-proxy` when null."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -245,6 +245,12 @@ variable "certificate_map" {
   default     = null
 }
 
+variable "certificate_manager_certificates" {
+  description = "Certificate Manager certificate self-links to associate with the HTTPS proxy. Requires `ssl` to be set to `true`. Cannot be combined with `certificate_map`."
+  type        = list(string)
+  default     = []
+}
+
 variable "ssl_policy" {
   type        = string
   description = "Selfink to SSL Policy"


### PR DESCRIPTION
Closes #600.
Supersedes #598.

## Changes

### modules/frontend

- **`certificate_manager_certificates`** — direct cert attachment to target HTTPS proxy; resolves `ssl_certificates` to `null` when set to avoid conflicts
- **`url_map_config`** — full URL map expression via variable: `host_rules`, `path_matchers` with `default_url_redirect`, `path_rules` (with `url_redirect`), `route_rules` with `header_matches` and `route_action.weighted_backend_services`
- **Resource name overrides** — `url_map_name`, `target_http_proxy_name`, `target_https_proxy_name`, `http_forwarding_rule_name`, `https_forwarding_rule_name`, `forwarding_rule_names` (map), `http_forwarding_rule_names` (map)
- **`ip_version`** — for external forwarding rules

### modules/backend

- `ip_address_selection_policy`, `health_check_self_links`, `preference` on backend groups
- `log_config.sample_rate` optional, `log_config.optional_mode`
- `compression_mode` and `request_coalescing` in `cdn_policy` for backend buckets and services

## Backward compatibility

All new variables default to `null` or `[]`. No existing configuration is affected.

## Validation

All changes are in production use for INTERNAL_MANAGED and EXTERNAL_MANAGED LBs.