### PR TITLE
feat: add log_config support to health check firewall rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ module "gce-lb-http" {
 | create\_url\_map | Set to `false` if url\_map variable is provided. | `bool` | `true` | no |
 | edge\_security\_policy | The resource URL for the edge security policy to associate with the backend service | `string` | `null` | no |
 | enable\_ipv6 | Enable IPv6 address on the CDN load-balancer | `bool` | `false` | no |
+| firewall\_log\_config | Firewall logging configuration for the health check firewall rule. | <pre>object({<br>    metadata = optional(string)<br>  })</pre> | `null` | no |
 | firewall\_networks | Names of the networks to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | firewall\_projects | Names of the projects to create firewall rules in | `list(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -451,4 +451,11 @@ resource "google_compute_firewall" "default-hc" {
       ports    = [allow.value["health_check"].port]
     }
   }
+
+  dynamic "log_config" {
+    for_each = var.firewall_log_config != null ? [var.firewall_log_config] : []
+    content {
+      metadata = log_config.value.metadata
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,14 @@ variable "firewall_projects" {
   default     = ["default"]
 }
 
+variable "firewall_log_config" {
+  description = "Firewall logging configuration for the health check firewall rule."
+  type = object({
+    metadata = optional(string)
+  })
+  default = null
+}
+
 variable "target_tags" {
   description = "List of target tags for health check firewall rule. Exactly one of target_tags or target_service_accounts should be specified."
   type        = list(string)


### PR DESCRIPTION
Fixes #606

**What this PR does / why we need it:**
The health-check firewall rule resource (`google_compute_firewall.default-hc`) didn't expose the `log_config` block, so firewall logging couldn't be enabled for this rule through the module.

**Changes:**
- `variables.tf`: add an optional `firewall_log_config` object variable (`{ metadata = optional(string) }`, default `null`).
- `main.tf`: add a `dynamic "log_config"` block on `google_compute_firewall.default-hc`, populated from `var.firewall_log_config` when set.
- `README.md`: regenerate the variable documentation table to include the new input.

**Special notes for your reviewer:**
- Backwards compatible — `firewall_log_config` defaults to `null`, so the `log_config` block is omitted entirely unless explicitly configured, preserving existing behavior.
- Mirrors the pattern used for `log_config` on `google_compute_backend_service` elsewhere in this module (see #605).